### PR TITLE
[infra] VPC, Subnet 설정 및 Github Actions 기반 CI/CD 파이프라인 구축 (#4)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -43,6 +43,7 @@ jobs:
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/orange
 
   CD:
+    if: github.event.pull_request.merged == true && github.ref == 'refs/heads/dev'
     runs-on: self-hosted
     needs: CI
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,54 @@
+# CI/CD workflow
+name: CI/CD
+
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+permissions:
+  contents: read
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v1
+
+        # TODO: 추후 테스트코드 작성 후 테스트 실패 시 CI 불가능하도록 수정
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build Docker Image
+        run: docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/orange .
+
+      - name: Push Docker Image
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/orange
+
+  CD:
+    runs-on: self-hosted
+    needs: CI
+
+    steps:
+      - name: Remove Docker Container
+        run: sudo docker rm -f orange || true
+
+      - name: Run Updated Docker Container
+        run: sudo docker run -t --env-file ./.env -d --name orange -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/orange

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v1
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
 
         # TODO: 추후 테스트코드 작성 후 테스트 실패 시 CI 불가능하도록 수정
       - name: Build with Gradle

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,7 @@ out/
 .vscode/
 
 ### project
+*.sh
+*.yml
 *.yaml
 *.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use OpenJDK 17 as the base image
+FROM openjdk:17
+
+# Specify the build argument for the JAR file
+ARG JAR_FILE=build/libs/*.jar
+
+# Copy the JAR file into the container
+COPY ${JAR_FILE} app.jar
+
+# Set the entry point to run the JAR file
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,15 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 	annotationProcessor 'com.github.therapi:therapi-runtime-javadoc-scribe:0.13.0'
 	implementation 'com.github.therapi:therapi-runtime-javadoc:0.13.0'
+
+	// mysql
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.data:spring-data-redis'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #4 

# 📝 작업 내용

> 전반적인 AWS 인프라를 설정하였고, Github Actions로 CI/CD 파이프라인을 구축했습니다. 제대로 동작하는지는 추가적인 검증이 필요합니다.

## 작업 상세 내용
- [x] VPC 설정
- [x] Public/Private Subnet 생성, 라우팅 테이블과 게이트웨이 등 여러 인프라 설정
- [x] Springboot 프로젝트 Docker image로 빌드 및 푸쉬
- [x] Public subnet에 Springboot 배치하고 Private subnet엔 Redis+mySQL 배치하고 서로 연결 (연결 성공)
- [x] 중요 변수 .env 파일에 은닉하고 빌드 시 포함
- [x] Github Actions 기반 CI 설정 (검증 필요)
- [x] 머지 완료 시 Github Actions 기반 CD 설정 (검증 필요)

## 참고 이미지 및 자료
[인프라 설정 과정](https://velog.io/@win-luck/AWS-VPC%EB%A1%9C-PublicPrivate-Subnet-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)
[Docker 빌드 시 환경변수 별도 파일로 은닉](https://velog.io/@ghdud0503/Docker-%EA%B8%B0%EC%B4%88-6-%ED%99%98%EA%B2%BD%EB%B3%80%EC%88%98-%EB%AA%85%EB%A0%B9%EC%96%B4-%EC%8B%A4%ED%96%89)

# 💬 리뷰 요구사항
> 혹시나 문제될 부분, 개선할 부분이 있는지 점검해주시면 감사하겠습니다. 특히, 민감한 변수들을 은닉할 .env 파일을 어떻게 관리할지에 대해 세부적인 논의가 추가로 필요해 보입니다! 
현재는 EC2 상에 작성된 env 파일을 활용하고 있으나, 추후 Github Secret 변수들을 모아 Dockerfile 상에서 env 파일을 생성하는 방법도 좋아 보입니다.