### PR TITLE
[fix] entity 필드 이름 문제 및 관계 누락 문제 수정(#8)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventWinningInfo.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.event.draw.entity;
 
+import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -12,9 +13,14 @@ public class DrawEventWinningInfo {
     private Long id;
 
     @Column
-    private Long rank;
+    private Long ranking;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "draw_event_id")
     private DrawEvent drawEvent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_user_id")
+    private EventUser eventUser;
+
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.event.fcfs.entity;
 
+import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -11,7 +12,11 @@ public class FcfsEventWinningInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "fcfs_event_id")
     private FcfsEvent fcfsEvent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name ="event_user_id")
+    private EventUser eventUser;
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
@@ -2,6 +2,8 @@ package hyundai.softeer.orange.eventuser.entity;
 
 import hyundai.softeer.orange.comment.entity.Comment;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
+import hyundai.softeer.orange.event.draw.entity.DrawEventWinningInfo;
+import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -31,4 +33,10 @@ public class EventUser {
 
     @OneToMany(mappedBy = "eventUser")
     private List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "eventUser")
+    private List<DrawEventWinningInfo> drawEventWinningInfoList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "eventUser")
+    private List<FcfsEventWinningInfo> fcfsEventWinningInfoList = new ArrayList<>();
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #8

# 📝 작업 내용

> DrawEventWinningInfo 엔티티가 가지고 있던 "rank" 필드는 mysql의 예약어 (window 함수)이므로, 해당 이름의 필드를 포함한 테이블을 만들 수 없는 문제가 있어 수정했습니다. 또한 EventUser - WinningInfo 사이의 관계가 누락되어 있어, 이 부분을 추가했습니다.