### PR TITLE
[infra] CI와 CD 별도 파일로 분리 (#4)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,30 @@
+name: CD
+
+on:
+  pull_request:
+    branches: [ "dev" ]
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Remove Docker Container
+        run: sudo docker rm -f orange || true
+
+      - name: Run Updated Docker Container
+        run: sudo docker run -t --env-file ./.env -d --name orange -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/orange

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,4 @@
-# CI/CD workflow
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -12,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  CI:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +26,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
 
-        # TODO: 추후 테스트코드 작성 후 테스트 실패 시 CI 불가능하도록 수정
       - name: Build with Gradle
         run: ./gradlew build -x test
 
@@ -42,21 +40,3 @@ jobs:
 
       - name: Push Docker Image
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/orange
-
-  CD:
-    runs-on: self-hosted
-    needs: CI
-    if: github.event.pull_request.merged == true
-
-    steps:
-      - name: Docker Login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Remove Docker Container
-        run: sudo docker rm -f orange || true
-
-      - name: Run Updated Docker Container
-        run: sudo docker run -t --env-file ./.env -d --name orange -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/orange


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #4 

# 📝 작업 내용

> CD가 처리되지 않는 문제 해결을 위해 CI와 CD를 별도의 파일로 분리하였고, 오직 Merged 되었을 때만 실행되도록 명시적으로 표현했습니다.

## 참고 이미지 및 자료


# 💬 리뷰 요구사항
