### PR TITLE
[infra] 서버가 로그를 파일 형태로 관리할 수 있게 설정 추가 (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 *.yml
 *.yaml
 *.properties
+**/*.env*

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ out/
 
 ### project
 *.sh
-*.yml
-*.yaml
+**/resources/*.yml
 *.properties
 **/*.env*
+**/.DS_store

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  spring_server:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+#    env_file:
+#      - ./.env
+    volumes:
+      # 로그 파일 경로 잡기
+      - /var/log:/var/log
+    ports:
+      - 8080:8080
+  promtail:
+    image: grafana/promtail
+    env_file:
+      - ./.env.promtail
+    volumes:
+      - ./promtail-config.yaml:/etc/promtail/config.yaml
+      - /var/log:/var/log
+    command:
+      -config.file=/etc/promtail/config.yaml
+      -config.expand-env=true

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -15,8 +15,8 @@ services:
     env_file:
       - ./.env.promtail
     volumes:
-      - ./promtail-config.yaml:/etc/promtail/config.yaml
+      - ./promtail-config.yml:/etc/promtail/config.yml
       - /var/log:/var/log
     command:
-      -config.file=/etc/promtail/config.yaml
+      -config.file=/etc/promtail/config.yml
       -config.expand-env=true

--- a/infra/promtail-config.yml
+++ b/infra/promtail-config.yml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: ${PROMTAIL_PORT}
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: "${LOKI_URL}"
+
+scrape_configs:
+  - job_name: spring-boot
+    static_configs:
+      - targets:
+        - localhost
+        labels:
+          job: springboot
+          __path__: /var/log/spring-boot/*.log

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=orange

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,29 @@
+<configuration>
+    <property name="LOG_DIR" value="/var/log/spring-boot" />
+    <!-- 콘솔 출력 설정 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 일반 파일 출력 설정 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/general.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <!-- 지난 로그는 loghistory로 저장 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- 로그 파일 이름 설정: 날짜별 -->
+            <fileNamePattern>${LOG_DIR}/general-%d{yyyy-MM-dd}.loghistory</fileNamePattern>
+            <maxHistory>7</maxHistory> <!-- 로그 파일을 최대 7일 동안 유지 -->
+        </rollingPolicy>
+    </appender>
+
+    <!-- 루트 로거 설정: 콘솔 및 일반 파일에 로그 저장 -->
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #7

# 📝 작업 내용

1. 기존에 구현되어 있던 spring docker file을 기반으로 로그를 로컬 환경에 파일 형태로 저장할 수 있도록 구성했습니다.
2. promtail을 docker-compose로 연결, spring 환경의 로그를 수집하고 loki로 넘길 수 있게 구성했습니다.
3. 로컬에 docker 컨테이너로 띄워 둔 loki 및 그라파나와 연동해본 결과 정상적으로 로그를 수집하는 것을 볼 수 있었습니다.

## 참고 이미지 및 자료
> 로컬 환경의 그라파나가 수집된 로그를 보여주고 있습니다.
![image](https://github.com/user-attachments/assets/6c0f75de-f942-4bbd-9552-c3edc7bd3840)