### PR TITLE
 [feat] 선착순 이벤트 구현방안 1: Redis Lock 기반 (#23)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.data:spring-data-redis'
 
+	// redisson
+	implementation 'org.redisson:redisson:3.16.2'
+
 	// valid
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, false, "부정적인 표현을 사용하였습니다."),
     INVALID_JSON(HttpStatus.BAD_REQUEST, false, "잘못된 JSON 형식입니다."),
+    INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, false, "이벤트 시간이 아닙니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, false, "인증되지 않은 사용자입니다."),
@@ -25,6 +26,7 @@ public enum ErrorCode {
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+    FCFS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "선착순 이벤트를 찾을 수 없습니다."),
     EVENT_FRAME_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 프레임을 찾을 수 없습니다."),
     EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 사용자를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "기대평을 찾을 수 없습니다."),

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
     COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 등록된 기대평입니다."),
     ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 관리자입니다."),
+    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, false, "이미 참여한 이벤트입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다.");

--- a/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
+++ b/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
@@ -31,23 +31,8 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errors);
     }
 
-    @ExceptionHandler({CommentException.class, AdminException.class})
-    public ResponseEntity<ErrorResponse> handleCommentException(BaseException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
-    }
-
-    @ExceptionHandler(EventUserException.class)
-    public ResponseEntity<ErrorResponse> handleEventUserException(EventUserException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
-    }
-
-    @ExceptionHandler(FcfsEventException.class)
-    public ResponseEntity<ErrorResponse> handleFcfsEventException(FcfsEventException e) {
-        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
-    }
-
-    @ExceptionHandler(InternalServerException.class)
-    public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException e) {
+    @ExceptionHandler({CommentException.class, AdminException.class, EventUserException.class, FcfsEventException.class, InternalServerException.class})
+    public ResponseEntity<ErrorResponse> handleException(BaseException e) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
+++ b/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package hyundai.softeer.orange.common;
 
 import hyundai.softeer.orange.admin.exception.AdminException;
 import hyundai.softeer.orange.comment.exception.CommentException;
+import hyundai.softeer.orange.common.exception.InternalServerException;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
 import hyundai.softeer.orange.eventuser.exception.EventUserException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,6 +38,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EventUserException.class)
     public ResponseEntity<ErrorResponse> handleEventUserException(EventUserException e) {
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(FcfsEventException.class)
+    public ResponseEntity<ErrorResponse> handleFcfsEventException(FcfsEventException e) {
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(InternalServerException.class)
+    public ResponseEntity<ErrorResponse> handleInternalServerException(InternalServerException e) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/config/WebConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/WebConfig.java
@@ -17,7 +17,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor);
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/swagger-ui/**");
     }
 
     @Override

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/ResponseFcfsWinnerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/ResponseFcfsWinnerDto.java
@@ -1,0 +1,16 @@
+package hyundai.softeer.orange.event.fcfs;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class ResponseFcfsWinnerDto {
+
+    private String name;
+    private String phoneNumber;
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/config/RedissonConfig.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/config/RedissonConfig.java
@@ -1,0 +1,27 @@
+package hyundai.softeer.orange.event.fcfs.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -1,0 +1,31 @@
+package hyundai.softeer.orange.event.fcfs.controller;
+
+import hyundai.softeer.orange.event.fcfs.service.FcfsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "fcfs", description = "선착순 이벤트 관련 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/event/fcfs")
+@RestController
+public class FcfsController {
+
+    private final FcfsService fcfsService;
+
+    @Tag(name = "fcfs")
+    @PostMapping
+    @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
+            @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패"),
+            @ApiResponse(responseCode = "400", description = "선착순 이벤트 시간이 아니거나, 요청 형식이 잘못된 경우"),
+    })
+    public ResponseEntity<Boolean> participate(@RequestParam Long eventSequence, @RequestParam String userId) {
+        return ResponseEntity.ok(fcfsService.participate(eventSequence, userId));
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
@@ -2,7 +2,9 @@ package hyundai.softeer.orange.event.fcfs.entity;
 
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @Table(name="fcfs_event")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class FcfsEvent {
     @Id
@@ -34,4 +37,14 @@ public class FcfsEvent {
 
     @OneToMany(mappedBy = "fcfsEvent")
     private List<FcfsEventWinningInfo> infos = new ArrayList<>();
+
+    public static FcfsEvent of(LocalDateTime startTime, LocalDateTime endTime, Long participantCount, String prizeInfo, EventMetadata eventMetadata) {
+        FcfsEvent fcfsEvent = new FcfsEvent();
+        fcfsEvent.startTime = startTime;
+        fcfsEvent.endTime = endTime;
+        fcfsEvent.participantCount = participantCount;
+        fcfsEvent.prizeInfo = prizeInfo;
+        fcfsEvent.eventMetadata = eventMetadata;
+        return fcfsEvent;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
@@ -2,10 +2,13 @@ package hyundai.softeer.orange.event.fcfs.entity;
 
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Table(name="fcfs_event_winning_info")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class FcfsEventWinningInfo {
     @Id
@@ -19,4 +22,11 @@ public class FcfsEventWinningInfo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name ="event_user_id")
     private EventUser eventUser;
+
+    public static FcfsEventWinningInfo of(FcfsEvent fcfsEvent, EventUser eventUser) {
+        FcfsEventWinningInfo fcfsEventWinningInfo = new FcfsEventWinningInfo();
+        fcfsEventWinningInfo.fcfsEvent = fcfsEvent;
+        fcfsEventWinningInfo.eventUser = eventUser;
+        return fcfsEventWinningInfo;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/exception/FcfsEventException.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/exception/FcfsEventException.java
@@ -1,0 +1,10 @@
+package hyundai.softeer.orange.event.fcfs.exception;
+
+import hyundai.softeer.orange.common.BaseException;
+import hyundai.softeer.orange.common.ErrorCode;
+
+public class FcfsEventException extends BaseException {
+    public FcfsEventException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventRepository.java
@@ -4,6 +4,11 @@ import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface FcfsEventRepository extends JpaRepository<FcfsEvent, Long> {
+
+    List<FcfsEvent> findByStartTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
@@ -2,8 +2,15 @@ package hyundai.softeer.orange.event.fcfs.repository;
 
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface FcfsEventWinningInfoRepository extends JpaRepository<FcfsEventWinningInfo, Long> {
+
+    // Fetch Join으로 eventUser 정보까지 한번에 가져와서 N+1 문제 방지
+    @Query("select f from FcfsEventWinningInfo f join fetch f.eventUser where f.fcfsEvent.id = :eventSequence")
+    List<FcfsEventWinningInfo> findByFcfsEventId(Long eventSequence);
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
@@ -1,0 +1,25 @@
+package hyundai.softeer.orange.event.fcfs.scheduler;
+
+import hyundai.softeer.orange.event.fcfs.service.FcfsManageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class FcfsScheduler {
+
+    private final FcfsManageService fcfsManageService;
+
+    // 매일 자정 1분마다 실행되며, 오늘의 선착순 이벤트에 대한 정보를 DB에서 Redis로 이동시킨다.
+    @Scheduled(cron = "0 1 0 * * *")
+    public void registerFcfsEvents() {
+        fcfsManageService.registerFcfsEvents();
+    }
+
+    // 매일 자정마다 실행되며, 선착순 이벤트 당첨자들을 Redis에서 DB로 이동시킨다.
+    @Scheduled(cron = "0 0 0 * * *")
+    public void registerWinners() {
+        fcfsManageService.registerWinners();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -36,7 +36,7 @@ public class FcfsManageService {
         List<FcfsEvent> events = fcfsEventRepository.findByStartTimeBetween(LocalDateTime.now(), LocalDateTime.now().plusDays(1));
         events.forEach(event -> {
             redissonClient.getBucket(FcfsUtil.keyFormatting(event.getId().toString())).set(event.getParticipantCount());
-            redissonClient.getBucket(FcfsUtil.startTimeFormatting(event.getId().toString())).set(event.getStartTime());
+            stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(event.getId().toString()), event.getStartTime().toString());
         });
     }
 
@@ -69,7 +69,8 @@ public class FcfsManageService {
                     .toList();
 
             fcfsEventWinningInfoRepository.saveAll(winningInfos);
-            stringRedisTemplate.delete(fcfsId);
+            redissonClient.getBucket(FcfsUtil.keyFormatting(eventId)).delete();
+            stringRedisTemplate.delete(FcfsUtil.startTimeFormatting(eventId));
         }
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -1,0 +1,86 @@
+package hyundai.softeer.orange.event.fcfs.service;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.fcfs.ResponseFcfsWinnerDto;
+import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
+import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventWinningInfoRepository;
+import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class FcfsManageService {
+
+    private final EventUserRepository eventUserRepository;
+    private final FcfsEventRepository fcfsEventRepository;
+    private final FcfsEventWinningInfoRepository fcfsEventWinningInfoRepository;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedissonClient redissonClient;
+
+    // 오늘의 선착순 이벤트 정보(당첨자 수, 시작 시각)를 Redis에 배치
+    @Transactional(readOnly = true)
+    public void registerFcfsEvents() {
+        List<FcfsEvent> events = fcfsEventRepository.findByStartTimeBetween(LocalDateTime.now(), LocalDateTime.now().plusDays(1));
+        events.forEach(event -> {
+            redissonClient.getBucket(FcfsUtil.quantityKeyFormatting(event.getId().toString())).set(event.getParticipantCount());
+            redissonClient.getBucket(FcfsUtil.startTimeFormatting(event.getId().toString())).set(event.getStartTime());
+        });
+    }
+
+    // redis에 저장된 모든 선착순 이벤트의 당첨자 정보를 DB로 이관
+    @Transactional
+    public void registerWinners() {
+        Set<String> fcfsIds = stringRedisTemplate.keys("*:fcfs");
+        if (fcfsIds == null || fcfsIds.isEmpty()) {
+            return;
+        }
+
+        for(String fcfsId : fcfsIds) {
+            List<String> userIds = stringRedisTemplate.opsForList().range(fcfsId, 0, -1);
+            if(userIds == null || userIds.isEmpty()) {
+                return;
+            }
+
+            FcfsEvent event = fcfsEventRepository.findById(Long.parseLong(fcfsId))
+                    .orElseThrow(() -> new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND));
+
+            List<EventUser> users = eventUserRepository.findAllById(
+                    userIds.stream()
+                            .map(Long::parseLong)
+                            .toList());
+
+            List<FcfsEventWinningInfo> winningInfos = users
+                    .stream()
+                    .map(user -> FcfsEventWinningInfo.of(event, user))
+                    .toList();
+
+            fcfsEventWinningInfoRepository.saveAll(winningInfos);
+            stringRedisTemplate.delete(fcfsId);
+        }
+    }
+
+    // 특정 선착순 이벤트의 당첨자 조회 - 어드민에서 사용
+    @Transactional(readOnly = true)
+    public List<ResponseFcfsWinnerDto> getFcfsWinnersInfo(Long eventSequence) {
+        return fcfsEventWinningInfoRepository.findByFcfsEventId(eventSequence)
+                .stream()
+                .map(winningInfo -> ResponseFcfsWinnerDto.builder()
+                        .name(winningInfo.getEventUser().getUserName())
+                        .phoneNumber(winningInfo.getEventUser().getPhoneNumber())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsService.java
@@ -1,0 +1,6 @@
+package hyundai.softeer.orange.event.fcfs.service;
+
+public interface FcfsService {
+    boolean participate(Long eventSequence, String userId);
+
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -1,0 +1,77 @@
+package hyundai.softeer.orange.event.fcfs.service;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisLockFcfsService implements FcfsService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedissonClient redissonClient;
+
+    @Override
+    public boolean participate(Long eventSequence, String userId) {
+        // time check
+        LocalDateTime startTime = (LocalDateTime) redissonClient.getBucket(FcfsUtil.startTimeFormatting(eventSequence.toString())).get();
+        if (LocalDateTime.now().isBefore(startTime)){
+            throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
+        }
+
+        final String fcfsId = FcfsUtil.quantityKeyFormatting(eventSequence.toString());
+        if (isEventEnded(fcfsId)) { // 불필요한 Lock 접근을 막기 위한 flag 확인
+            log.info("{} 선착순 이벤트 마감", fcfsId);
+            return false;
+        }
+
+        final RLock lock = redissonClient.getLock(fcfsId);
+
+        try {
+            boolean usingLock = lock.tryLock(1L, 3L, TimeUnit.SECONDS);
+            if (!usingLock) {
+                return false;
+            }
+
+            final long quantity = availableCoupons(fcfsId);
+            if (quantity <= 0) {
+                endEvent(fcfsId);  // 이벤트 종료 플래그 설정
+                return false;
+            }
+
+            redissonClient.getBucket(fcfsId).set(quantity);
+            stringRedisTemplate.opsForList().rightPush(fcfsId, userId);
+            log.info("{} - 잔여 쿠폰: {}", Thread.currentThread().getName(), availableCoupons(fcfsId));
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private int availableCoupons(String key) {
+        return (int) redissonClient.getBucket(key).get();
+    }
+
+    private boolean isEventEnded(String fcfsId) {
+        return redissonClient.getBucket(FcfsUtil.endFlagFormatting(fcfsId)).get() != null;
+    }
+
+    private void endEvent(String fcfsId) {
+        redissonClient.getBucket(FcfsUtil.endFlagFormatting(fcfsId)).set(true);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -1,0 +1,20 @@
+package hyundai.softeer.orange.event.fcfs.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FcfsUtil {
+
+    public static String quantityKeyFormatting(String fcfsId) {
+        return fcfsId + ":fcfs";
+    }
+
+    public static String startTimeFormatting(String fcfsId) {
+        return fcfsId + "_start";
+    }
+
+    public static String endFlagFormatting(String fcfsId) {
+        return fcfsId + "_end";
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -17,4 +17,8 @@ public class FcfsUtil {
     public static String endFlagFormatting(String fcfsId) {
         return fcfsId + "_end";
     }
+
+    public static String winnerFormatting(String fcfsId) {
+        return fcfsId + "_winner";
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FcfsUtil {
 
-    public static String quantityKeyFormatting(String fcfsId) {
+    public static String keyFormatting(String fcfsId) {
         return fcfsId + ":fcfs";
     }
 

--- a/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
@@ -12,6 +12,7 @@ import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.common.util.MessageUtil;
+import hyundai.softeer.orange.core.jwt.JWTManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,9 @@ class CommentControllerTest {
 
     @MockBean
     private ApiService apiService;
+
+    @MockBean
+    private JWTManager jwtManager;
 
     ObjectMapper mapper = new ObjectMapper();
     CreateCommentDto createCommentDto = new CreateCommentDto(1L, 1L, "hello");

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsControllerTest.java
@@ -1,0 +1,82 @@
+package hyundai.softeer.orange.event.fcfs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.common.ErrorResponse;
+import hyundai.softeer.orange.core.jwt.JWTManager;
+import hyundai.softeer.orange.event.fcfs.controller.FcfsController;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.fcfs.service.FcfsService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = FcfsController.class)
+class FcfsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockBean
+    private FcfsService fcfsService;
+
+    @MockBean
+    private JWTManager jwtManager;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @DisplayName("participate: 선착순 이벤트 참여 성공 및 실패")
+    @ParameterizedTest(name = "flag: {0}")
+    @ValueSource(booleans = {true, false})
+    void participateTest(boolean flag) throws Exception {
+        // given
+        when(fcfsService.participate(1L, "hyundai")).thenReturn(flag);
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event/fcfs")
+                .param("eventSequence", "1")
+                .param("userId", "hyundai"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(String.valueOf(flag)));
+    }
+
+    @DisplayName("participate: 선착순 이벤트 참여 시 이벤트 시간이 아니어서 예외가 발생하는 경우")
+    @Test
+    void participate400Test() throws Exception {
+        // given
+        when(fcfsService.participate(1L, "hyundai")).thenThrow(new FcfsEventException(ErrorCode.INVALID_EVENT_TIME));
+        String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_EVENT_TIME));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event/fcfs")
+                .param("eventSequence", "1")
+                .param("userId", "hyundai"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(responseBody));
+    }
+
+    @DisplayName("participate: 선착순 이벤트 참여 시 요청 형식이 잘못된 경우")
+    @ParameterizedTest(name = "eventSequence: {0}")
+    @ValueSource(strings = {"", " ", "a", "1.1", "1.0", "1.1.1", ""})
+    void participateBadInputTest(String eventSequence) throws Exception {
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event/fcfs")
+                .param("eventSequence", eventSequence)
+                .param("userId", "hyundai"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceUnitTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceUnitTest.java
@@ -1,0 +1,117 @@
+package hyundai.softeer.orange.event.fcfs;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.common.entity.EventFrame;
+import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
+import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventWinningInfoRepository;
+import hyundai.softeer.orange.event.fcfs.service.FcfsManageService;
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+class FcfsManageServiceUnitTest {
+
+    @InjectMocks
+    private FcfsManageService fcfsManageService;
+
+    @Mock
+    private EventUserRepository eventUserRepository;
+
+    @Mock
+    private FcfsEventRepository fcfsEventRepository;
+
+    @Mock
+    private FcfsEventWinningInfoRepository fcfsEventWinningInfoRepository;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ListOperations<String, String> valueOperations;
+
+    EventFrame eventFrame = EventFrame.of("hyundai");
+    List<FcfsEvent> events = List.of(
+            FcfsEvent.of(LocalDateTime.now(), LocalDateTime.now().plusDays(1), 10L, "prizeInfo", null));
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        given(stringRedisTemplate.opsForList()).willReturn(valueOperations);
+    }
+
+    @DisplayName("registerWinners: redis에 저장된 모든 선착순 이벤트의 당첨자 정보를 DB로 이관한다.")
+    @Test
+    void registerWinnersTest(){
+        // given
+        given(stringRedisTemplate.keys("*:fcfs")).willReturn(Set.of("1:fcfs"));
+        given(stringRedisTemplate.opsForList().range("1", 0, -1)).willReturn(List.of("1"));
+        given(fcfsEventRepository.findById(1L)).willReturn(Optional.of(events.get(0)));
+        given(eventUserRepository.findAllById(List.of(1L, 2L))).willReturn(List.of(
+                EventUser.of("test1", "01012345678", eventFrame, "1")));
+
+        // when
+        fcfsManageService.registerWinners();
+
+        // then
+        verify(fcfsEventWinningInfoRepository, times(1)).saveAll(anyList());
+        verify(stringRedisTemplate, times(1)).delete("1:fcfs");
+    }
+
+    @DisplayName("registerWinners: 잘못된 eventId로 조회할 경우 예외를 발생시킨다.")
+    @Test
+    void registerWinnersNotFoundTest(){
+        // given
+        given(stringRedisTemplate.keys("*:fcfs")).willReturn(Set.of("1:fcfs"));
+        given(stringRedisTemplate.opsForList().range("1", 0, -1)).willReturn(List.of("1"));
+        given(fcfsEventRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> fcfsManageService.registerWinners())
+                .isInstanceOf(FcfsEventException.class)
+                .hasMessage(ErrorCode.FCFS_EVENT_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("getFcfsWinnersInfo: 특정 선착순 이벤트의 당첨자를 조회한다.")
+    @Test
+    void getFcfsWinnersInfoTest(){
+        // given
+        List<EventUser> eventUsers = List.of(
+                EventUser.of("test1", "01012345678", eventFrame, "1"),
+                EventUser.of("test2", "01000000001", eventFrame, "2"));
+        List<FcfsEventWinningInfo> fcfsEventWinningInfos = List.of(
+                FcfsEventWinningInfo.of(events.get(0), eventUsers.get(0)),
+                FcfsEventWinningInfo.of(events.get(0), eventUsers.get(1)));
+        given(fcfsEventRepository.findById(1L)).willReturn(java.util.Optional.ofNullable(events.get(0)));
+        given(fcfsEventWinningInfoRepository.findByFcfsEventId(1L)).willReturn(fcfsEventWinningInfos);
+
+        // when
+        List<ResponseFcfsWinnerDto> fcfsWinnerDtos = fcfsManageService.getFcfsWinnersInfo(1L);
+
+        // then
+        assertThat(fcfsWinnerDtos).hasSize(2);
+        assertThat(fcfsWinnerDtos.get(0).getName()).isEqualTo("test1");
+        assertThat(fcfsWinnerDtos.get(0).getPhoneNumber()).isEqualTo("01012345678");
+        assertThat(fcfsWinnerDtos.get(1).getName()).isEqualTo("test2");
+        assertThat(fcfsWinnerDtos.get(1).getPhoneNumber()).isEqualTo("01000000001");
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
@@ -1,0 +1,82 @@
+package hyundai.softeer.orange.event.fcfs;
+
+import hyundai.softeer.orange.event.fcfs.service.RedisLockFcfsService;
+import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
+import org.junit.jupiter.api.*;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@SpringBootTest
+class RedisLockFcfsServiceLoadTest {
+
+    @Autowired
+    private RedisLockFcfsService redisLockFcfsService;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private RedissonClient redissonClient;
+
+    Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
+
+    @BeforeEach
+    void setUp() {
+        // 필요한 경우 이전 데이터 삭제
+        redissonClient.getKeys().flushdb();
+        redissonClient.getKeys().flushall();
+
+        // 테스트할 이벤트 정보 저장
+        redissonClient.getBucket(FcfsUtil.keyFormatting(eventSequence.toString())).set(30);
+        stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
+    }
+
+    @AfterEach
+    void tearDown() {
+        stringRedisTemplate.delete(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+    }
+
+    @DisplayName("부하 테스트: 1000명의 사용자가 동시에 참여를 시도한다.")
+    @Test
+    void loadTestParticipate() throws InterruptedException {
+        int numberOfThreads = 1000; // 스레드 수
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        String userIdPrefix = "user"; // 사용자 ID 접두사
+
+        // 테스트 시작 시간
+        long startTime = System.currentTimeMillis();
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            final int index = i;
+            executorService.execute(() -> {
+                try {
+                    boolean result = redisLockFcfsService.participate(1L, userIdPrefix + index);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 스레드가 완료될 때까지 대기
+        latch.await();
+
+        // 테스트 종료 시간
+        long endTime = System.currentTimeMillis();
+        log.info("Total time: {} ms", endTime - startTime);
+
+        // 스레드 풀 종료
+        executorService.shutdown();
+    }
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #23 

# 📝 작업 내용

> 선착순 이벤트를 기존에 조사했던 Redis Lock 기반으로 구현하였습니다. 추후 SortedSet, MessageQueue, DB Table 등 여러 방안과 연계하고 객관적인 성능을 측정한 보고서를 작성할 것입니다.

## 참고 이미지 및 자료
![image](https://github.com/user-attachments/assets/cc1b5bbc-1ada-4afb-85e0-3169c936e271)


# 💬 리뷰 요구사항
현재 Fcfs 그 자체 메커니즘을 구현하는 메서드인 participate()는 별도로 인터페이스화하여, 다른 구현방안도 문제 없이 구현체에 담아 사용할 수 있도록 설계했습니다. 한편, FCFS 이벤트 자체를 등록하는 로직은 스케줄러 기반으로 FcfsManageService에 보관하여 관리와 구현을 분리했습니다. (관리는 Redis 캐싱을 통해 이루어질 것이기 때문입니다.) 리뷰해주실 때 유의해주세요!