### PR TITLE
[feat] 단축 URL 구현 (#26)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, false, "부정적인 표현을 사용하였습니다."),
     INVALID_JSON(HttpStatus.BAD_REQUEST, false, "잘못된 JSON 형식입니다."),
+    INVALID_URL(HttpStatus.BAD_REQUEST, false, "유효하지 않은 URL입니다."),
     INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, false, "이벤트 시간이 아닙니다."),
     INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, false, "이벤트 타입이 지원되지 않습니다."),
 
@@ -28,6 +29,7 @@ public enum ErrorCode {
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+    SHORT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, false, "단축 URL을 찾을 수 없습니다."),
     FCFS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "선착순 이벤트를 찾을 수 없습니다."),
     EVENT_FRAME_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 프레임을 찾을 수 없습니다."),
     EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 사용자를 찾을 수 없습니다."),
@@ -38,6 +40,7 @@ public enum ErrorCode {
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
+    SHORT_URL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 URL입니다."),
     COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 등록된 기대평입니다."),
     ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 관리자입니다."),
 

--- a/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
+++ b/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import hyundai.softeer.orange.comment.exception.CommentException;
 
 import hyundai.softeer.orange.common.exception.InternalServerException;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.url.exception.UrlException;
 import hyundai.softeer.orange.eventuser.exception.EventUserException;
 
 import org.springframework.http.HttpStatus;
@@ -33,7 +34,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().body(errors);
     }
 
-    @ExceptionHandler({CommentException.class, AdminException.class, EventUserException.class, FcfsEventException.class, InternalServerException.class})
+    @ExceptionHandler({CommentException.class, AdminException.class, EventUserException.class, FcfsEventException.class, UrlException.class, InternalServerException.class})
     public ResponseEntity<ErrorResponse> handleException(BaseException e) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
     }

--- a/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
+++ b/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
@@ -13,8 +13,11 @@ public class ConstantUtil {
     public static final String AUTH_CODE_REGEX = "\\d{6}"; // 6자리 숫자
     public static final String AUTH_CODE_CREATE_REGEX = "%06d";
     public static final String CLAIMS_KEY = "user";
+    public static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    public static final String LOCATION = "Location";
 
     public static final double LIMIT_NEGATIVE_CONFIDENCE = 99.5;
     public static final int COMMENTS_SIZE = 20;
     public static final int SCHEDULED_TIME = 1000 * 60 * 60 * 2;
+    public static final int SHORT_URL_LENGTH = 10;
 }

--- a/src/main/java/hyundai/softeer/orange/config/WebConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/WebConfig.java
@@ -20,7 +20,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor);
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/swagger-ui/**");
     }
 
     @Override

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
@@ -1,4 +1,4 @@
-package hyundai.softeer.orange.event.fcfs;
+package hyundai.softeer.orange.event.fcfs.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -1,7 +1,7 @@
 package hyundai.softeer.orange.event.fcfs.service;
 
 import hyundai.softeer.orange.common.ErrorCode;
-import hyundai.softeer.orange.event.fcfs.ResponseFcfsWinnerDto;
+import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsWinnerDto;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -33,7 +33,7 @@ public class UrlController {
     })
     public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String originalUrl, @RequestParam String userId){
         // TODO: JWT 토큰으로부터 userId를 추출하여 사용하도록 추후 수정
-        return ResponseEntity.ok(urlService.generateUrl(originalUrl, userId));
+        return ResponseEntity.ok(urlService.generateUrl(originalUrl));
     }
 
     @Tag(name = "Url")

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -31,9 +31,9 @@ public class UrlController {
             @ApiResponse(responseCode = "404", description = "유저를 찾지 못했을 때",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String longUrl, @RequestParam String userId){
+    public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String originalUrl, @RequestParam String userId){
         // TODO: JWT 토큰으로부터 userId를 추출하여 사용하도록 추후 수정
-        return ResponseEntity.ok(urlService.generateUrl(longUrl, userId));
+        return ResponseEntity.ok(urlService.generateUrl(originalUrl, userId));
     }
 
     @Tag(name = "Url")
@@ -45,7 +45,7 @@ public class UrlController {
     })
     public ResponseEntity<Void> redirectToOriginalUrl(@PathVariable String shortUrl){
         return ResponseEntity.status(302)
-                .header(ConstantUtil.LOCATION, urlService.getLongUrl(shortUrl))
+                .header(ConstantUtil.LOCATION, urlService.getOriginalUrl(shortUrl))
                 .build();
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -1,0 +1,26 @@
+package hyundai.softeer.orange.event.url.controller;
+
+import hyundai.softeer.orange.common.util.ConstantUtil;
+import hyundai.softeer.orange.event.url.service.UrlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+public class UrlController {
+
+    private final UrlService urlService;
+
+    @PostMapping("/api/v1/url/shorten")
+    public ResponseEntity<String> urlShorten(@RequestParam String longUrl, @RequestParam String userId){
+        // TODO: JWT 토큰으로부터 userId를 추출하여 사용하도록 추후 수정
+        return ResponseEntity.ok(urlService.generateUrl(longUrl, userId));
+    }
+
+    @GetMapping("/{shortUrl}")
+    public ResponseEntity<Void> redirectToOriginalUrl(@PathVariable String shortUrl){
+        String longUrl = urlService.getLongUrl(shortUrl);
+        return ResponseEntity.status(302).header(ConstantUtil.LOCATION, longUrl).build();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Url", description = "단축 URL 관련 API")
+@RequestMapping("/api/v1/url")
 @RequiredArgsConstructor
 @RestController
 public class UrlController {
@@ -21,7 +22,7 @@ public class UrlController {
     private final UrlService urlService;
 
     @Tag(name = "Url")
-    @PostMapping("/api/v1/url/shorten")
+    @PostMapping("/shorten")
     @Operation(summary = "URL 단축", description = "URL을 단축하여 반환합니다.", responses = {
             @ApiResponse(responseCode = "200", description = "URL 단축 성공",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
@@ -38,8 +39,7 @@ public class UrlController {
     @Tag(name = "Url")
     @GetMapping("/{shortUrl}")
     @Operation(summary = "URL 리다이렉트", description = "단축 URL을 원본 URL로 리다이렉트합니다.", responses = {
-            @ApiResponse(responseCode = "302", description = "URL 리다이렉트",
-                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "302", description = "URL 리다이렉트"),
             @ApiResponse(responseCode = "404", description = "단축 URL을 찾지 못했을 때",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -25,7 +25,7 @@ public class UrlController {
     @PostMapping("/shorten")
     @Operation(summary = "URL 단축", description = "URL을 단축하여 반환합니다.", responses = {
             @ApiResponse(responseCode = "200", description = "URL 단축 성공",
-                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResponseUrlDto.class))),
             @ApiResponse(responseCode = "400", description = "URL 형식이 잘못되었을 때",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "404", description = "유저를 찾지 못했을 때",

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -1,26 +1,51 @@
 package hyundai.softeer.orange.event.url.controller;
 
+import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.common.util.ConstantUtil;
+import hyundai.softeer.orange.event.url.dto.ResponseUrlDto;
 import hyundai.softeer.orange.event.url.service.UrlService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Url", description = "단축 URL 관련 API")
 @RequiredArgsConstructor
 @RestController
 public class UrlController {
 
     private final UrlService urlService;
 
+    @Tag(name = "Url")
     @PostMapping("/api/v1/url/shorten")
-    public ResponseEntity<String> urlShorten(@RequestParam String longUrl, @RequestParam String userId){
+    @Operation(summary = "URL 단축", description = "URL을 단축하여 반환합니다.", responses = {
+            @ApiResponse(responseCode = "200", description = "URL 단축 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "URL 형식이 잘못되었을 때",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "유저를 찾지 못했을 때",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String longUrl, @RequestParam String userId){
         // TODO: JWT 토큰으로부터 userId를 추출하여 사용하도록 추후 수정
         return ResponseEntity.ok(urlService.generateUrl(longUrl, userId));
     }
 
+    @Tag(name = "Url")
     @GetMapping("/{shortUrl}")
+    @Operation(summary = "URL 리다이렉트", description = "단축 URL을 원본 URL로 리다이렉트합니다.", responses = {
+            @ApiResponse(responseCode = "302", description = "URL 리다이렉트",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "단축 URL을 찾지 못했을 때",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+    })
     public ResponseEntity<Void> redirectToOriginalUrl(@PathVariable String shortUrl){
-        String longUrl = urlService.getLongUrl(shortUrl);
-        return ResponseEntity.status(302).header(ConstantUtil.LOCATION, longUrl).build();
+        return ResponseEntity.status(302)
+                .header(ConstantUtil.LOCATION, urlService.getLongUrl(shortUrl))
+                .build();
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/dto/ResponseUrlDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/dto/ResponseUrlDto.java
@@ -1,0 +1,4 @@
+package hyundai.softeer.orange.event.url.dto;
+
+public record ResponseUrlDto(String url) {
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/dto/ResponseUrlDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/dto/ResponseUrlDto.java
@@ -1,4 +1,14 @@
 package hyundai.softeer.orange.event.url.dto;
 
-public record ResponseUrlDto(String url) {
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ResponseUrlDto {
+    private String shortUrl;
+
+    public ResponseUrlDto(String shortUrl) {
+        this.shortUrl = shortUrl;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
@@ -1,0 +1,34 @@
+package hyundai.softeer.orange.event.url.entity;
+
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "url")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Url {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String shortUrl;
+
+    private String longUrl;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_user_id")
+    private EventUser eventUser;
+
+    public static Url of(String longUrl, String url, EventUser eventUser) {
+        Url shortUrl = new Url();
+        shortUrl.longUrl = longUrl;
+        shortUrl.shortUrl = url;
+        shortUrl.eventUser = eventUser;
+        return shortUrl;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
@@ -1,6 +1,5 @@
 package hyundai.softeer.orange.event.url.entity;
 
-import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,15 +19,10 @@ public class Url {
 
     private String shortUrl;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "event_user_id")
-    private EventUser eventUser;
-
-    public static Url of(String originalUrl, String shortUrl, EventUser eventUser) {
+    public static Url of(String originalUrl, String shortUrl) {
         Url url = new Url();
         url.originalUrl = originalUrl;
         url.shortUrl = shortUrl;
-        url.eventUser = eventUser;
         return url;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/entity/Url.java
@@ -16,19 +16,19 @@ public class Url {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String shortUrl;
+    private String originalUrl;
 
-    private String longUrl;
+    private String shortUrl;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_user_id")
     private EventUser eventUser;
 
-    public static Url of(String longUrl, String url, EventUser eventUser) {
-        Url shortUrl = new Url();
-        shortUrl.longUrl = longUrl;
-        shortUrl.shortUrl = url;
-        shortUrl.eventUser = eventUser;
-        return shortUrl;
+    public static Url of(String originalUrl, String shortUrl, EventUser eventUser) {
+        Url url = new Url();
+        url.originalUrl = originalUrl;
+        url.shortUrl = shortUrl;
+        url.eventUser = eventUser;
+        return url;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/exception/UrlException.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/exception/UrlException.java
@@ -1,0 +1,10 @@
+package hyundai.softeer.orange.event.url.exception;
+
+import hyundai.softeer.orange.common.BaseException;
+import hyundai.softeer.orange.common.ErrorCode;
+
+public class UrlException extends BaseException {
+    public UrlException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/repository/UrlRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/repository/UrlRepository.java
@@ -1,0 +1,11 @@
+package hyundai.softeer.orange.event.url.repository;
+
+import hyundai.softeer.orange.event.url.entity.Url;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UrlRepository extends JpaRepository<Url, Long> {
+    boolean existsByShortUrl(String shortUrl);
+    Optional<Url> findByShortUrl(String shortUrl);
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -10,7 +10,6 @@ import hyundai.softeer.orange.event.url.util.UrlTypeValidation;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,8 +23,8 @@ public class UrlService {
     private final EventUserRepository eventUserRepository;
 
     @Transactional
-    public ResponseUrlDto generateUrl(String longUrl, String userId) {
-        if(!UrlTypeValidation.valid(longUrl)){
+    public ResponseUrlDto generateUrl(String originalUrl, String userId) {
+        if(!UrlTypeValidation.valid(originalUrl)){
             throw new UrlException(ErrorCode.INVALID_URL);
         }
         EventUser eventUser = eventUserRepository.findByUserId(userId)
@@ -36,15 +35,15 @@ public class UrlService {
             shortUrl = generateShortUrl();
         }
 
-        Url url = Url.of(longUrl, shortUrl, eventUser);
+        Url url = Url.of(originalUrl, shortUrl, eventUser);
         return new ResponseUrlDto(urlRepository.save(url).getShortUrl());
     }
 
     @Transactional(readOnly = true)
-    public String getLongUrl(String url) {
+    public String getOriginalUrl(String url) {
         Url shortUrl = urlRepository.findByShortUrl(url)
                 .orElseThrow(() -> new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
-        return shortUrl.getLongUrl();
+        return shortUrl.getOriginalUrl();
     }
 
     private String generateShortUrl() {

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -2,6 +2,7 @@ package hyundai.softeer.orange.event.url.service;
 
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.util.ConstantUtil;
+import hyundai.softeer.orange.event.url.dto.ResponseUrlDto;
 import hyundai.softeer.orange.event.url.entity.Url;
 import hyundai.softeer.orange.event.url.exception.UrlException;
 import hyundai.softeer.orange.event.url.repository.UrlRepository;
@@ -26,7 +27,7 @@ public class UrlService {
     private String baseUrl;
 
     @Transactional
-    public String generateUrl(String longUrl, String userId) {
+    public ResponseUrlDto generateUrl(String longUrl, String userId) {
         if(!UrlTypeValidation.valid(longUrl)){
             throw new UrlException(ErrorCode.INVALID_URL);
         }
@@ -39,7 +40,7 @@ public class UrlService {
         }
 
         Url url = Url.of(longUrl, baseUrl + shortUrl, eventUser);
-        return urlRepository.save(url).getShortUrl();
+        return new ResponseUrlDto(urlRepository.save(url).getShortUrl());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -20,13 +20,12 @@ public class UrlService {
     private final UrlRepository urlRepository;
 
     @Transactional
-    public ResponseUrlDto generateUrl(String originalUrl, String userId) {
+    public ResponseUrlDto generateUrl(String originalUrl) {
         if(!UrlTypeValidation.isValidURL(originalUrl)){
             throw new UrlException(ErrorCode.INVALID_URL);
         }
 
         // originalUrl에 userId 추가
-        originalUrl += "?userId=" + userId;
         String shortUrl = generateShortUrl();
         while(urlRepository.existsByShortUrl(shortUrl)){
             shortUrl = generateShortUrl();

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -38,10 +38,10 @@ public class UrlService {
     }
 
     @Transactional(readOnly = true)
-    public String getOriginalUrl(String url) {
-        Url shortUrl = urlRepository.findByShortUrl(url)
+    public String getOriginalUrl(String shortUrl) {
+        Url url = urlRepository.findByShortUrl(shortUrl)
                 .orElseThrow(() -> new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
-        return shortUrl.getOriginalUrl();
+        return url.getOriginalUrl().split("\\?")[0];
     }
 
     private String generateShortUrl() {

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -40,7 +40,7 @@ public class UrlService {
     public String getOriginalUrl(String shortUrl) {
         Url url = urlRepository.findByShortUrl(shortUrl)
                 .orElseThrow(() -> new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
-        return url.getOriginalUrl().split("\\?")[0];
+        return url.getOriginalUrl();
     }
 
     private String generateShortUrl() {

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -23,9 +23,6 @@ public class UrlService {
     private final UrlRepository urlRepository;
     private final EventUserRepository eventUserRepository;
 
-    @Value("${base.url}")
-    private String baseUrl;
-
     @Transactional
     public ResponseUrlDto generateUrl(String longUrl, String userId) {
         if(!UrlTypeValidation.valid(longUrl)){
@@ -39,7 +36,7 @@ public class UrlService {
             shortUrl = generateShortUrl();
         }
 
-        Url url = Url.of(longUrl, baseUrl + shortUrl, eventUser);
+        Url url = Url.of(longUrl, shortUrl, eventUser);
         return new ResponseUrlDto(urlRepository.save(url).getShortUrl());
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -1,0 +1,61 @@
+package hyundai.softeer.orange.event.url.service;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.common.util.ConstantUtil;
+import hyundai.softeer.orange.event.url.entity.Url;
+import hyundai.softeer.orange.event.url.exception.UrlException;
+import hyundai.softeer.orange.event.url.repository.UrlRepository;
+import hyundai.softeer.orange.event.url.util.UrlTypeValidation;
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class UrlService {
+
+    private final UrlRepository urlRepository;
+    private final EventUserRepository eventUserRepository;
+
+    @Value("${base.url}")
+    private String baseUrl;
+
+    @Transactional
+    public String generateUrl(String longUrl, String userId) {
+        if(!UrlTypeValidation.valid(longUrl)){
+            throw new UrlException(ErrorCode.INVALID_URL);
+        }
+        EventUser eventUser = eventUserRepository.findByUserId(userId)
+                .orElseThrow(() -> new UrlException(ErrorCode.EVENT_USER_NOT_FOUND));
+
+        String shortUrl = generateShortUrl();
+        while(urlRepository.existsByShortUrl(shortUrl)){
+            shortUrl = generateShortUrl();
+        }
+
+        Url url = Url.of(longUrl, baseUrl + shortUrl, eventUser);
+        return urlRepository.save(url).getShortUrl();
+    }
+
+    @Transactional(readOnly = true)
+    public String getLongUrl(String url) {
+        Url shortUrl = urlRepository.findByShortUrl(url)
+                .orElseThrow(() -> new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
+        return shortUrl.getLongUrl();
+    }
+
+    private String generateShortUrl() {
+        String characters = ConstantUtil.CHARACTERS;
+        Random random = new Random();
+        StringBuilder shortUrlsb = new StringBuilder(ConstantUtil.SHORT_URL_LENGTH);
+        for (int i = 0; i < ConstantUtil.SHORT_URL_LENGTH; i++) {
+            shortUrlsb.append(characters.charAt(random.nextInt(characters.length())));
+        }
+        return shortUrlsb.toString();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -25,9 +25,11 @@ public class UrlService {
             throw new UrlException(ErrorCode.INVALID_URL);
         }
 
-        String shortUrl = generateShortUrl(userId);
+        // originalUrl에 userId 추가
+        originalUrl += "?userId=" + userId;
+        String shortUrl = generateShortUrl();
         while(urlRepository.existsByShortUrl(shortUrl)){
-            shortUrl = generateShortUrl(userId);
+            shortUrl = generateShortUrl();
         }
 
         Url url = Url.of(originalUrl, shortUrl);
@@ -42,15 +44,13 @@ public class UrlService {
         return shortUrl.getOriginalUrl();
     }
 
-    private String generateShortUrl(String userId) {
+    private String generateShortUrl() {
         String characters = ConstantUtil.CHARACTERS;
         Random random = new Random();
         StringBuilder shortUrlsb = new StringBuilder(ConstantUtil.SHORT_URL_LENGTH);
         for (int i = 0; i < ConstantUtil.SHORT_URL_LENGTH; i++) {
             shortUrlsb.append(characters.charAt(random.nextInt(characters.length())));
         }
-        // QueryString으로 userId를 추가
-        shortUrlsb.append("?userId=").append(userId);
         return shortUrlsb.toString();
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/url/util/UrlTypeValidation.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/util/UrlTypeValidation.java
@@ -1,0 +1,23 @@
+package hyundai.softeer.orange.event.url.util;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.net.URLConnection;
+
+@Component
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UrlTypeValidation {
+    public static boolean valid(String url) {
+        try {
+            URL connectionUrl = new URL(url);
+            URLConnection conn = connectionUrl.openConnection();
+            conn.connect();
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/url/util/UrlTypeValidation.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/util/UrlTypeValidation.java
@@ -2,22 +2,20 @@ package hyundai.softeer.orange.event.url.util;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
 
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
-import java.net.URLConnection;
 
-@Component
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UrlTypeValidation {
-    public static boolean valid(String url) {
+
+    public static boolean isValidURL(String url) {
         try {
-            URL connectionUrl = new URL(url);
-            URLConnection conn = connectionUrl.openConnection();
-            conn.connect();
-        } catch (Exception e) {
+            new URL(url).toURI();
+            return true;
+        } catch (MalformedURLException | URISyntaxException e) {
             return false;
         }
-        return true;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface EventUserRepository extends JpaRepository<EventUser, Long> {
 
     Optional<EventUser> findByUserNameAndPhoneNumber(String userName, String phoneNumber);
+
+    Optional<EventUser> findByUserId(String userId);
 }

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceUnitTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceUnitTest.java
@@ -2,6 +2,7 @@ package hyundai.softeer.orange.event.fcfs;
 
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
+import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsWinnerDto;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;

--- a/src/test/java/hyundai/softeer/orange/event/url/UrlControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/url/UrlControllerTest.java
@@ -45,7 +45,7 @@ class UrlControllerTest {
     @Test
     void urlShortenTest() throws Exception {
         // given
-        when(urlService.generateUrl(originalUrl, userId)).thenReturn(new ResponseUrlDto("shortUrl"));
+        when(urlService.generateUrl(originalUrl)).thenReturn(new ResponseUrlDto("shortUrl"));
         String responseBody = mapper.writeValueAsString(new ResponseUrlDto("shortUrl"));
 
         // when & then
@@ -61,7 +61,7 @@ class UrlControllerTest {
     @Test
     void urlShorten400Test() throws Exception {
         // given
-        when(urlService.generateUrl(originalUrl, userId)).thenThrow(new UrlException(ErrorCode.INVALID_URL));
+        when(urlService.generateUrl(originalUrl)).thenThrow(new UrlException(ErrorCode.INVALID_URL));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_URL));
 
         // when & then
@@ -77,7 +77,7 @@ class UrlControllerTest {
     @Test
     void urlShorten404Test() throws Exception {
         // given
-        when(urlService.generateUrl(originalUrl, userId)).thenThrow(new UrlException(ErrorCode.USER_NOT_FOUND));
+        when(urlService.generateUrl(originalUrl)).thenThrow(new UrlException(ErrorCode.USER_NOT_FOUND));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.USER_NOT_FOUND));
 
         // when & then

--- a/src/test/java/hyundai/softeer/orange/event/url/UrlControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/url/UrlControllerTest.java
@@ -1,0 +1,117 @@
+package hyundai.softeer.orange.event.url;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.common.ErrorResponse;
+import hyundai.softeer.orange.core.jwt.JWTManager;
+import hyundai.softeer.orange.event.url.controller.UrlController;
+import hyundai.softeer.orange.event.url.dto.ResponseUrlDto;
+import hyundai.softeer.orange.event.url.exception.UrlException;
+import hyundai.softeer.orange.event.url.service.UrlService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UrlController.class)
+class UrlControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockBean
+    private JWTManager jwtManager;
+
+    @MockBean
+    private UrlService urlService;
+
+    ObjectMapper mapper = new ObjectMapper();
+    String originalUrl = "https://www.google.com";
+    String shortUrl = "shortUrl";
+    String userId = "test";
+
+    @DisplayName("urlShorten: originalUrl과 userId를 전달받아 ResponseUrlDto를 반환한다.")
+    @Test
+    void urlShortenTest() throws Exception {
+        // given
+        when(urlService.generateUrl(originalUrl, userId)).thenReturn(new ResponseUrlDto("shortUrl"));
+        String responseBody = mapper.writeValueAsString(new ResponseUrlDto("shortUrl"));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                .post("/api/v1/url/shorten")
+                .param("originalUrl", originalUrl)
+                .param("userId", userId))
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseBody));
+    }
+
+    @DisplayName("urlShorten: originalUrl이 유효하지 않은 경우 ErrorResponse를 반환한다.")
+    @Test
+    void urlShorten400Test() throws Exception {
+        // given
+        when(urlService.generateUrl(originalUrl, userId)).thenThrow(new UrlException(ErrorCode.INVALID_URL));
+        String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_URL));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                .post("/api/v1/url/shorten")
+                .param("originalUrl", originalUrl)
+                .param("userId", userId))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(responseBody));
+    }
+
+    @DisplayName("urlShorten: userId가 존재하지 않는 경우 ErrorResponse를 반환한다.")
+    @Test
+    void urlShorten404Test() throws Exception {
+        // given
+        when(urlService.generateUrl(originalUrl, userId)).thenThrow(new UrlException(ErrorCode.USER_NOT_FOUND));
+        String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                .post("/api/v1/url/shorten")
+                .param("originalUrl", originalUrl)
+                .param("userId", userId))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(responseBody));
+    }
+
+    @DisplayName("redirectToOriginalUrl: shortUrl을 전달받아 원본 URL로 리다이렉트한다.")
+    @Test
+    void redirectToOriginalUrlTest() throws Exception {
+        // given
+        when(urlService.getOriginalUrl(shortUrl)).thenReturn("https://www.google.com");
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/api/v1/url/" + shortUrl))
+                .andExpect(status().isFound());
+    }
+
+    @DisplayName("redirectToOriginalUrl: shortUrl이 존재하지 않는 경우 예외가 발생해야 한다.")
+    @Test
+    void redirectToOriginalUrl404Test() throws Exception {
+        // given
+        when(urlService.getOriginalUrl(shortUrl)).thenThrow(new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
+        String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.SHORT_URL_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders
+                .get("/api/v1/url/" + shortUrl))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(responseBody));
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/url/UrlServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/url/UrlServiceTest.java
@@ -1,0 +1,89 @@
+package hyundai.softeer.orange.event.url;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.url.dto.ResponseUrlDto;
+import hyundai.softeer.orange.event.url.entity.Url;
+import hyundai.softeer.orange.event.url.exception.UrlException;
+import hyundai.softeer.orange.event.url.repository.UrlRepository;
+import hyundai.softeer.orange.event.url.service.UrlService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+class UrlServiceTest {
+
+    @InjectMocks
+    private UrlService urlService;
+
+    @Mock
+    private UrlRepository urlRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    String originalUrl = "https://www.naver.com";
+    String userId = "test";
+    String shortUrl = "https://www.naver.com?userId=test";
+
+    @DisplayName("generateUrl: 단축 URL을 생성한다.")
+    @Test
+    void generateUrlTest() {
+        // given
+        given(urlRepository.existsByShortUrl(shortUrl)).willReturn(false);
+
+        // when
+        ResponseUrlDto result = urlService.generateUrl(originalUrl, userId);
+
+        // then
+        assertThat(result.getShortUrl()).isNotNull();
+        verify(urlRepository).save(any());
+    }
+
+    @DisplayName("generateUrl: 단축 URL을 생성할 때 원본 URL이 유효하지 않으면 예외를 발생시킨다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"", " ", "      ", "htppss://naver.com", "ww.naver.com", "navercom"})
+    void generateUrlBadInputTest(String originalUrl) {
+        // when & then
+        assertThatThrownBy(() -> urlService.generateUrl(originalUrl, userId))
+                .isInstanceOf(UrlException.class)
+                .hasMessage(ErrorCode.INVALID_URL.getMessage());
+    }
+
+    @DisplayName("getOriginalUrl: 단축 URL에 해당하는 원본 URL을 조회한다.")
+    @Test
+    void getOriginalUrlTest() {
+        // given
+        given(urlRepository.findByShortUrl(shortUrl)).willReturn(java.util.Optional.of(Url.of(originalUrl, shortUrl)));
+
+        // when
+        String result = urlService.getOriginalUrl(shortUrl);
+
+        // then
+        assertThat(result).isEqualTo(originalUrl);
+    }
+
+    @DisplayName("getOriginalUrl: 단축 URL에 해당하는 원본 URL이 없으면 예외를 발생시킨다.")
+    @Test
+    void getOriginalUrlNotFoundTest() {
+        // given
+        given(urlRepository.findByShortUrl(shortUrl)).willReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> urlService.getOriginalUrl(shortUrl))
+                .isInstanceOf(UrlException.class)
+                .hasMessage(ErrorCode.SHORT_URL_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/url/UrlServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/url/UrlServiceTest.java
@@ -45,7 +45,7 @@ class UrlServiceTest {
         given(urlRepository.existsByShortUrl(shortUrl)).willReturn(false);
 
         // when
-        ResponseUrlDto result = urlService.generateUrl(originalUrl, userId);
+        ResponseUrlDto result = urlService.generateUrl(originalUrl);
 
         // then
         assertThat(result.getShortUrl()).isNotNull();
@@ -57,7 +57,7 @@ class UrlServiceTest {
     @ValueSource(strings = {"", " ", "      ", "htppss://naver.com", "ww.naver.com", "navercom"})
     void generateUrlBadInputTest(String originalUrl) {
         // when & then
-        assertThatThrownBy(() -> urlService.generateUrl(originalUrl, userId))
+        assertThatThrownBy(() -> urlService.generateUrl(originalUrl))
                 .isInstanceOf(UrlException.class)
                 .hasMessage(ErrorCode.INVALID_URL.getMessage());
     }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #26 

# 📝 작업 내용
> 빠르고 간결하게 난수 기반의 단축 URL을 구현하였습니다.
- [x] Url Entity 및 Repository 구성
- [x] longUrl을 난수 기반으로 shortUrl로 변경하고 userId를 FK로 등록
- [x] shortUrl을 PathVariable로 받아 리다이렉트 기능 구현
- [x] 단위테스트 작성 및 실제 API 호출을 통한 기능 검증
- [x] 코드리뷰 피드백 반영

## 참고 이미지 및 자료
![image](https://github.com/user-attachments/assets/3b96d76c-7369-40b8-a1fb-d7f741efc726)
보통 위 형태로 단축 URL이 구성되나, 요구사항에서 벗어나 있는 만큼 난수를 기반으로 신속하게 구현했습니다.

* 구체적으로, FE가 original Url을 전송하면 서버는 이를 받아 전송한 유저의 id를 FK로 하는 Url Entity를 생성합니다.
* FE의 특정 페이지 {FE BaseURL}/{shortUrl}의 링크를 클라이언트가 클릭한다면, 클라이언트는 백엔드의 redirectToOriginalUrl 함수의 엔드포인트(/api/v1/url/{shortUrl})로 GET 요청을 보냅니다.
* 백엔드는 PathVariable 형태의 shortUrl을 기반으로 DB에서 찾은 Original Url로 클라이언트에게 리다이렉트를 요청하게 됩니다.
* 클라이언트는 Original Url로 이동합니다.

# 💬 리뷰 요구사항
