### PR TITLE
[feat] 선착순 이벤트 구현방안 2: Redis SortedSet 기반 (#29)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     SHORT_URL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 URL입니다."),
     COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 등록된 기대평입니다."),
     ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 관리자입니다."),
+    ALREADY_WINNER(HttpStatus.CONFLICT, false, "이미 당첨된 사용자입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다.");

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 등록된 기대평입니다."),
     ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 관리자입니다."),
     ALREADY_WINNER(HttpStatus.CONFLICT, false, "이미 당첨된 사용자입니다."),
+    PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 전화번호입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다.");

--- a/src/main/java/hyundai/softeer/orange/config/RedisConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/RedisConfig.java
@@ -45,6 +45,26 @@ public class RedisConfig {
         return new StringRedisTemplate(connectionFactory);
     }
 
+    // 선착순 이벤트의 종료 여부 flag를 저장하기 위해 사용
+    @Bean
+    public RedisTemplate<String, Boolean> booleanRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Boolean> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
+    // 선착순 이벤트의 참여 가능 인원수를 저장하기 위해 사용
+    @Bean
+    public RedisTemplate<String, Integer> numberRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+
     @Bean
     public CacheManager diareatCacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -52,7 +52,7 @@ public class FcfsManageService {
 
         for(String fcfsId : fcfsIds) {
             String eventId = fcfsId.replace(":fcfs", "");
-            List<String> userIds = stringRedisTemplate.opsForList().range(eventId, 0, -1);
+            Set<String> userIds = stringRedisTemplate.opsForZSet().range(FcfsUtil.winnerFormatting(eventId), 0, -1);
             if(userIds == null || userIds.isEmpty()) {
                 return;
             }
@@ -73,6 +73,7 @@ public class FcfsManageService {
             fcfsEventWinningInfoRepository.saveAll(winningInfos);
 
             stringRedisTemplate.delete(FcfsUtil.startTimeFormatting(event.getId().toString()));
+            stringRedisTemplate.delete(FcfsUtil.winnerFormatting(event.getId().toString()));
             numberRedisTemplate.delete(FcfsUtil.keyFormatting(eventId));
             booleanRedisTemplate.delete(FcfsUtil.endFlagFormatting(eventId));
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @RequiredArgsConstructor
 @Service
+@Primary
 public class RedisLockFcfsService implements FcfsService {
 
     private final StringRedisTemplate stringRedisTemplate;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -82,7 +82,8 @@ public class RedisLockFcfsService implements FcfsService {
     }
 
     private boolean isEventEnded(String fcfsId) {
-        return booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(fcfsId)) != null;
+        Boolean endFlag = booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(fcfsId));
+        return Boolean.TRUE.equals(endFlag);
     }
 
     private void endEvent(String fcfsId) {

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -1,0 +1,80 @@
+package hyundai.softeer.orange.event.fcfs.service;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
+import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisLuaFcfsService implements FcfsService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, Integer> numberRedisTemplate;
+    private final RedisTemplate<String, Boolean> booleanRedisTemplate;
+
+    @Override
+    public boolean participate(Long eventSequence, String userId) {
+        String fcfsId = FcfsUtil.keyFormatting(eventSequence.toString());
+        if (isEventEnded(fcfsId)) {
+            return false;
+        }
+
+        // 이미 당첨된 사용자인지 확인
+        if(stringRedisTemplate.opsForZSet().rank(FcfsUtil.winnerFormatting(eventSequence.toString()), userId) != null){
+            throw new FcfsEventException(ErrorCode.ALREADY_WINNER);
+        }
+
+        // 잘못된 이벤트 참여 시간
+        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+        if(startTime == null) {
+            throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
+        }
+
+        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+            throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
+        }
+
+        long timestamp = System.currentTimeMillis();
+        String script = "local count = redis.call('zcard', KEYS[1]) " +
+                "if count < tonumber(ARGV[1]) then " +
+                "    redis.call('zadd', KEYS[1], ARGV[2], ARGV[3]) " +
+                "    return redis.call('zcard', KEYS[1]) " +
+                "else " +
+                "    return 0 " +
+                "end";
+        Long result = stringRedisTemplate.execute(
+                RedisScript.of(script, Long.class),
+                Collections.singletonList(FcfsUtil.winnerFormatting(eventSequence.toString())),
+                String.valueOf(numberRedisTemplate.opsForValue().get(fcfsId)),
+                String.valueOf(timestamp),
+                userId
+        );
+
+        if(result == null || result <= 0) {
+            endEvent(fcfsId);  // 이벤트 종료 플래그 설정
+            return false;
+        }
+
+        stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(eventSequence.toString()), userId, System.currentTimeMillis());
+        log.info("Event Sequence: {}, User ID: {}, Timestamp: {}", eventSequence, userId, timestamp);
+        return true;
+    }
+
+    private boolean isEventEnded(String fcfsId) {
+        return booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(fcfsId)) != null;
+    }
+
+    private void endEvent(String fcfsId) {
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(fcfsId), true);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "EventUser", description = "EventUser 관련 API")
 @RequiredArgsConstructor
@@ -51,13 +48,13 @@ public class EventUserController {
 
     // 인증번호 검증
     @Tag(name = "EventUser")
-    @PostMapping("/check-auth")
+    @PostMapping("/check-auth/{eventFrameId}")
     @Operation(summary = "인증번호 검증", description = "유저가 입력한 인증번호를 검증한다.", responses = {
             @ApiResponse(responseCode = "200", description = "인증번호 검증 성공"),
             @ApiResponse(responseCode = "400", description = "입력받은 정보의 유효성 검사가 실패했을 때"),
             @ApiResponse(responseCode = "401", description = "인증번호가 일치하지 않을 때")
     })
-    public ResponseEntity<TokenDto> checkAuthCode(@RequestBody @Valid RequestAuthCodeDto dto) {
-        return ResponseEntity.ok(eventUserService.checkAuthCode(dto));
+    public ResponseEntity<TokenDto> checkAuthCode(@PathVariable Long eventFrameId,  @RequestBody @Valid RequestAuthCodeDto dto) {
+        return ResponseEntity.ok(eventUserService.checkAuthCode(dto, eventFrameId));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/dto/RequestAuthCodeDto.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/dto/RequestAuthCodeDto.java
@@ -25,7 +25,4 @@ public class RequestAuthCodeDto {
     @NotNull
     @Pattern(regexp = ConstantUtil.AUTH_CODE_REGEX, message = MessageUtil.INVALID_AUTH_CODE)
     private String authCode;
-
-    @NotNull(message = MessageUtil.BAD_INPUT)
-    private Long eventFrameId;
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -12,4 +12,6 @@ public interface EventUserRepository extends JpaRepository<EventUser, Long> {
     Optional<EventUser> findByUserNameAndPhoneNumber(String userName, String phoneNumber);
 
     Optional<EventUser> findByUserId(String userId);
+
+    boolean existsByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
@@ -51,7 +51,7 @@ public class EventUserService {
      * 4. 전화번호로 발송된 인증번호가 존재하지 않는다면 400 예외
      */
     @Transactional
-    public TokenDto checkAuthCode(RequestAuthCodeDto dto) {
+    public TokenDto checkAuthCode(RequestAuthCodeDto dto, Long eventFrameId) {
         // Redis에서 인증번호 조회
         String authCode = stringRedisTemplate.opsForValue().get(dto.getPhoneNumber());
         if(authCode == null) {
@@ -66,7 +66,7 @@ public class EventUserService {
         stringRedisTemplate.delete(dto.getPhoneNumber());
 
         // DB에 유저 데이터 저장
-        EventFrame eventFrame = eventFrameRepository.findById(dto.getEventFrameId())
+        EventFrame eventFrame = eventFrameRepository.findById(eventFrameId)
                 .orElseThrow(() -> new EventUserException(ErrorCode.EVENT_FRAME_NOT_FOUND));
         String userId = UUID.randomUUID().toString().substring(0, 8);
         EventUser eventUser = EventUser.of(dto.getName(), dto.getPhoneNumber(), eventFrame, userId);

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
@@ -7,6 +7,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 import java.util.concurrent.CountDownLatch;
@@ -24,6 +25,12 @@ class RedisLockFcfsServiceLoadTest {
     private StringRedisTemplate stringRedisTemplate;
 
     @Autowired
+    private RedisTemplate<String, Boolean> booleanRedisTemplate;
+
+    @Autowired
+    private RedisTemplate<String, Integer> numberRedisTemplate;
+
+    @Autowired
     private RedissonClient redissonClient;
 
     Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
@@ -35,28 +42,32 @@ class RedisLockFcfsServiceLoadTest {
         redissonClient.getKeys().flushall();
 
         // 테스트할 이벤트 정보 저장
-        redissonClient.getBucket(FcfsUtil.keyFormatting(eventSequence.toString())).set(30);
+        numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), 30);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
     }
 
     @AfterEach
     void tearDown() {
+        // 테스트 종료 후 데이터 삭제
+        numberRedisTemplate.delete(FcfsUtil.keyFormatting(eventSequence.toString()));
         stringRedisTemplate.delete(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+        booleanRedisTemplate.delete(FcfsUtil.endFlagFormatting(eventSequence.toString()));
     }
 
     @DisplayName("부하 테스트: 1000명의 사용자가 동시에 참여를 시도한다.")
     @Test
     void loadTestParticipate() throws InterruptedException {
-        int numberOfThreads = 1000; // 스레드 수
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        int numberOfThreads = 200; // 스레드 수
+        int numberOfUsers = 1000; // 동시 참여 사용자 수
 
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfUsers);
         String userIdPrefix = "user"; // 사용자 ID 접두사
 
         // 테스트 시작 시간
         long startTime = System.currentTimeMillis();
 
-        for (int i = 0; i < numberOfThreads; i++) {
+        for (int i = 0; i < numberOfUsers; i++) {
             final int index = i;
             executorService.execute(() -> {
                 try {

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLockFcfsServiceLoadTest.java
@@ -42,6 +42,7 @@ class RedisLockFcfsServiceLoadTest {
         redissonClient.getKeys().flushall();
 
         // 테스트할 이벤트 정보 저장
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), false);
         numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), 30);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
     }

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLuaFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/RedisLuaFcfsServiceLoadTest.java
@@ -1,76 +1,63 @@
 package hyundai.softeer.orange.event.fcfs;
-
-import hyundai.softeer.orange.event.fcfs.service.RedisLockFcfsService;
+import hyundai.softeer.orange.event.fcfs.service.RedisLuaFcfsService;
 import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
-import org.junit.jupiter.api.*;
-import org.redisson.api.RedissonClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @Slf4j
 @SpringBootTest
-class RedisLockFcfsServiceLoadTest {
+class RedisLuaFcfsServiceLoadTest {
 
     @Autowired
-    private RedisLockFcfsService redisLockFcfsService;
+    RedisLuaFcfsService redisLuaFcfsService;
 
     @Autowired
-    private StringRedisTemplate stringRedisTemplate;
+    StringRedisTemplate stringRedisTemplate;
 
     @Autowired
-    private RedisTemplate<String, Boolean> booleanRedisTemplate;
+    RedisTemplate<String, Integer> numberRedisTemplate;
 
     @Autowired
-    private RedisTemplate<String, Integer> numberRedisTemplate;
-
-    @Autowired
-    private RedissonClient redissonClient;
+    RedisTemplate<String, Boolean> booleanRedisTemplate;
 
     Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
 
     @BeforeEach
     void setUp() {
-        // 필요한 경우 이전 데이터 삭제
-        redissonClient.getKeys().flushdb();
-        redissonClient.getKeys().flushall();
+        // 초기화
+        stringRedisTemplate.getConnectionFactory().getConnection().flushAll();
+        numberRedisTemplate.getConnectionFactory().getConnection().flushAll();
+        booleanRedisTemplate.getConnectionFactory().getConnection().flushAll();
 
         // 테스트할 이벤트 정보 저장
-        numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), 30);
+        numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), 100);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
     }
 
-    @AfterEach
-    void tearDown() {
-        // 테스트 종료 후 데이터 삭제
-        numberRedisTemplate.delete(FcfsUtil.keyFormatting(eventSequence.toString()));
-        stringRedisTemplate.delete(FcfsUtil.startTimeFormatting(eventSequence.toString()));
-        booleanRedisTemplate.delete(FcfsUtil.endFlagFormatting(eventSequence.toString()));
-    }
-
-    @DisplayName("부하 테스트: 1000명의 사용자가 동시에 참여를 시도한다.")
     @Test
-    void loadTestParticipate() throws InterruptedException {
+    void participateTest() throws InterruptedException {
         int numberOfThreads = 200; // 스레드 수
         int numberOfUsers = 1000; // 동시 참여 사용자 수
 
         ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-        CountDownLatch latch = new CountDownLatch(numberOfUsers);
 
-        // 테스트 시작 시간
         long startTime = System.currentTimeMillis();
-
+        CountDownLatch latch = new CountDownLatch(numberOfUsers);
         for (int i = 0; i < numberOfUsers; i++) {
             final int index = i;
             executorService.execute(() -> {
                 try {
-                    boolean result = redisLockFcfsService.participate(1L, "user" + index);
+                    boolean result = redisLuaFcfsService.participate(1L, "user" + index);
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {
@@ -79,14 +66,13 @@ class RedisLockFcfsServiceLoadTest {
             });
         }
 
-        // 모든 스레드가 완료될 때까지 대기
         latch.await();
 
-        // 테스트 종료 시간
         long endTime = System.currentTimeMillis();
         log.info("Total time: {} ms", endTime - startTime);
 
-        // 스레드 풀 종료
         executorService.shutdown();
+        Long count = stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(eventSequence.toString()));
+        assertThat(count).isEqualTo(100);
     }
 }

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -55,6 +56,7 @@ class EventUserControllerTest {
     ObjectMapper mapper = new ObjectMapper();
     RequestUserDto requestUserDto = new RequestUserDto("hyundai", "01000000000");
     TokenDto tokenDto = new TokenDto("token");
+    Long eventFrameId = 1L;
 
     @DisplayName("login: 로그인 API를 호출한다.")
     @ParameterizedTest(name = "name: {0}, phoneNumber: {1}")
@@ -130,13 +132,13 @@ class EventUserControllerTest {
     @Test
     void checkAuthCodeTest() throws Exception {
         // given
-        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456", 1L);
+        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456");
         String requestBody = mapper.writeValueAsString(requestAuthCodeDto);
         String responseBody = mapper.writeValueAsString(tokenDto);
-        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class))).thenReturn(tokenDto);
+        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyLong())).thenReturn(tokenDto);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isOk())
@@ -148,14 +150,14 @@ class EventUserControllerTest {
     @ValueSource(strings = {"", " ", "   ", "1234a", "1234a6", "1234567"})
     void checkAuthCode400Test(String code) throws Exception {
         // given
-        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", code, 1L);
+        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", code);
         String requestBody = mapper.writeValueAsString(requestAuthCodeDto);
         Map<String, String> expectedErrors = new HashMap<>();
         expectedErrors.put("authCode", MessageUtil.INVALID_AUTH_CODE);
         String responseBody = mapper.writeValueAsString(expectedErrors);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -167,13 +169,13 @@ class EventUserControllerTest {
     @Test
     void checkAuthCode401Test() throws Exception {
         // given
-        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456", 1L);
+        RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456");
         String requestBody = mapper.writeValueAsString(requestAuthCodeDto);
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_AUTH_CODE));
-        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class))).thenThrow(new EventUserException(ErrorCode.INVALID_AUTH_CODE));
+        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyLong())).thenThrow(new EventUserException(ErrorCode.INVALID_AUTH_CODE));
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isUnauthorized())

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
@@ -63,6 +63,7 @@ class EventUserServiceTest {
     TokenDto tokenDto = new TokenDto("token");
     EventFrame eventFrame = EventFrame.of("eventFrame");
     EventUser eventUser = EventUser.of("test", "01000000000", eventFrame, "uuid");
+    Long eventFrameId = 1L;
 
     @DisplayName("login: 유저가 로그인한다.")
     @Test
@@ -104,11 +105,10 @@ class EventUserServiceTest {
                 .name(eventUser.getUserName())
                 .phoneNumber(eventUser.getPhoneNumber())
                 .authCode(authCode)
-                .eventFrameId(1L)
                 .build();
 
         // when
-        TokenDto result = eventUserService.checkAuthCode(requestAuthCodeDto);
+        TokenDto result = eventUserService.checkAuthCode(requestAuthCodeDto, eventFrameId);
 
         // then
         assertThat(result.token()).isEqualTo(tokenDto.token());
@@ -131,7 +131,7 @@ class EventUserServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> eventUserService.checkAuthCode(requestAuthCodeDto))
+        assertThatThrownBy(() -> eventUserService.checkAuthCode(requestAuthCodeDto, eventFrameId))
                 .isInstanceOf(EventUserException.class)
                 .hasMessage(ErrorCode.INVALID_AUTH_CODE.getMessage());
     }
@@ -147,7 +147,7 @@ class EventUserServiceTest {
                 .build();
 
         // when & then
-        assertThatThrownBy(() -> eventUserService.checkAuthCode(requestAuthCodeDto))
+        assertThatThrownBy(() -> eventUserService.checkAuthCode(requestAuthCodeDto, eventFrameId))
                 .isInstanceOf(EventUserException.class)
                 .hasMessage(ErrorCode.BAD_REQUEST.getMessage());
     }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #29 

# 📝 작업 내용

> 사전 조사 결과를 바탕으로 SortedSet 기반의 선착순 이벤트를 구현하고, 기존 Redis Lock 코드를 리팩토링했습니다.
> 구체적인 설명은 코멘트에 포함하겠습니다.

- [x] 기존의 Redis Lock 코드 리팩토링하여 모든 구현방안에서 동일한 자료구조 사용하도록 일관성 개선
- [x] SortedSet 기반 구현
- [x] 부하 테스트 작성

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
