### PR TITLE
[feat] 어드민 이벤트 수정 기능 구현(#28)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// sms api
 	implementation 'net.nurigo:sdk:4.3.0'
+
+	// test db
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     EVENT_FRAME_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 프레임을 찾을 수 없습니다."),
     EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 사용자를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "기대평을 찾을 수 없습니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, false, "허용되지 않은 메서드입니다."),

--- a/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
+++ b/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
@@ -38,4 +38,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(BaseException e) {
         return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
     }
+
+    @ExceptionHandler({BaseException.class})
+    public ResponseEntity<ErrorResponse> handleAllBaseException(BaseException e) {
+        return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ErrorResponse.from(e.getErrorCode()));
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/config/AppConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/AppConfig.java
@@ -1,6 +1,7 @@
 package hyundai.softeer.orange.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +13,8 @@ public class AppConfig {
         ObjectMapper objectMapper = new ObjectMapper();
         // LocalDateTime파싱이 목적
         objectMapper.registerModule(new JavaTimeModule());
+        // timestamp를 문자열로 전달
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
@@ -7,24 +7,34 @@ import hyundai.softeer.orange.event.common.exception.EventException;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import hyundai.softeer.orange.event.draw.entity.DrawEventMetadata;
 import hyundai.softeer.orange.event.draw.entity.DrawEventScorePolicy;
+import hyundai.softeer.orange.event.draw.repository.DrawEventMetadataRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventScorePolicyRepository;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventDto;
+import hyundai.softeer.orange.event.dto.draw.DrawEventMetadataDto;
+import hyundai.softeer.orange.event.dto.draw.DrawEventScorePolicyDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * EventMetadata에 DrawEvent를 주입해주는 매퍼
  */
+@RequiredArgsConstructor
 @Component
 public class DrawEventFieldMapper implements EventFieldMapper {
+    private final DrawEventMetadataRepository deMetadataRepository;
+    private final DrawEventScorePolicyRepository deScorePolicyRepository;
+
     @Override
     public boolean canHandle(EventType eventType) {
         return eventType.equals(EventType.draw);
     }
 
     @Override
-    public void handle(EventMetadata metadata, EventDto eventDto) {
+    public void fetchToEventEntity(EventMetadata metadata, EventDto eventDto) {
         DrawEventDto dto = eventDto.getDraw();
         // 비어 있으면 안됨.
         if (dto == null) throw new EventException(ErrorCode.INVALID_JSON);
@@ -52,4 +62,127 @@ public class DrawEventFieldMapper implements EventFieldMapper {
         ).toList();
         event.setMetadataList(metadataList);
     }
+
+    @Override
+    public void fetchToDto(EventMetadata metadata, EventDto eventDto) {
+        Optional<DrawEvent> drawEventOpt = metadata.getDrawEventList().stream().findFirst();
+        // drawEvent 정보가 있으면 넣기
+        drawEventOpt.ifPresent(drawEvent -> {
+            DrawEventDto drawEventDto = DrawEventDto
+                    .builder()
+                    .id(drawEvent.getId())
+                    .metadata(drawEvent.getMetadataList().stream().map(
+                            it -> DrawEventMetadataDto.builder()
+                                    .id(it.getId())
+                                    .count(it.getCount())
+                                    .grade(it.getGrade())
+                                    .prizeInfo(it.getPrizeInfo())
+                                    .build()
+                    ).toList())
+                    .policies(drawEvent.getPolicyList().stream().map(
+                            it -> DrawEventScorePolicyDto.builder()
+                                    .id(it.getId())
+                                    .score(it.getScore())
+                                    .action(it.getAction())
+                                    .build()
+                    ).toList())
+                    .build();
+
+            eventDto.setDraw(drawEventDto);
+        });
+    }
+
+    @Override
+    public void editEventField(EventMetadata metadata, EventDto dto) {
+        Optional<DrawEvent> drawEventOpt = metadata.getDrawEventList().stream().findFirst();
+        DrawEvent drawEvent = drawEventOpt.orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        DrawEventDto drawEventDto = dto.getDraw();
+
+        editDrawEventMetadata(drawEvent, drawEventDto);
+        editDrawEventScorePolicy(drawEvent, drawEventDto);
+    }
+
+    // 나중에 가능하다면 리팩토링 방법 찾아보자. => set 기반 공통 로직 추출
+    private void editDrawEventMetadata(DrawEvent drawEvent, DrawEventDto drawEventDto) {
+        List<DrawEventMetadata> deMetadata = drawEvent.getMetadataList();
+
+        Map<Boolean, Map<Long, DrawEventMetadataDto>> deMetadataDtos = drawEventDto.getMetadata().stream()
+                .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(DrawEventMetadataDto::getId, it-> it)));
+        // true이면 created / false이면 updated
+        Map<Long, DrawEventMetadataDto> createdDtos = deMetadataDtos.get(true);
+        Map<Long, DrawEventMetadataDto> updatedDtos = deMetadataDtos.get(false);
+
+        Set<Long> updated = new HashSet<>(updatedDtos.keySet());
+        Set<Long> deleted = deMetadata.stream().map(DrawEventMetadata::getId).collect(Collectors.toSet());
+        // null은 created
+        updated.retainAll(deleted); // dto & entity 교집합 => updated
+        deleted.removeAll(updated); // entity에는 있는데 dto에는 없음 => deleted
+
+        for(DrawEventMetadata metadata : deMetadata) {
+            // update에 있는 경우
+            if(updated.contains(metadata.getId())) {
+                DrawEventMetadataDto dto = updatedDtos.get(metadata.getId());
+                metadata.updateCount(dto.getCount());
+                metadata.updateGrade(dto.getGrade());
+                metadata.updatePrizeInfo(dto.getPrizeInfo());
+            }
+            // delete에 있는 경우
+            else if(deleted.contains(metadata.getId())) {
+                deMetadataRepository.delete(metadata);
+            }
+        }
+        deMetadata.removeIf(it -> deleted.contains(it.getId()));
+
+        // 객체 생성 처리
+        for(DrawEventMetadataDto createdDto : createdDtos.values()) {
+            DrawEventMetadata drawEventMetadata = DrawEventMetadata.of(
+                    createdDto.getGrade(),
+                    createdDto.getCount(),
+                    createdDto.getPrizeInfo(),
+                    drawEvent
+            );
+            deMetadata.add(drawEventMetadata);
+        }
+    }
+
+    private void editDrawEventScorePolicy(DrawEvent drawEvent, DrawEventDto drawEventDto) {
+        List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();
+
+        Map<Boolean, Map<Long, DrawEventScorePolicyDto>> deMetadataDtos = drawEventDto.getPolicies().stream()
+                .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(DrawEventScorePolicyDto::getId, it-> it)));
+        // true이면 created / false이면 updated
+        Map<Long, DrawEventScorePolicyDto> createdDtos = deMetadataDtos.get(true);
+        Map<Long, DrawEventScorePolicyDto> updatedDtos = deMetadataDtos.get(false);
+
+        Set<Long> updated = new HashSet<>(updatedDtos.keySet());
+        Set<Long> deleted = policies.stream().map(DrawEventScorePolicy::getId).collect(Collectors.toSet());
+        // null은 created
+        updated.retainAll(deleted); // dto & entity 교집합 => updated
+        deleted.removeAll(updated); // entity에는 있는데 dto에는 없음 => deleted
+
+        for(DrawEventScorePolicy policy : policies) {
+            // update에 있는 경우
+            if(updated.contains(policy.getId())) {
+                DrawEventScorePolicyDto dto = updatedDtos.get(policy.getId());
+                policy.updateAction(dto.getAction());
+                policy.updateScore(dto.getScore());
+            }
+            // delete에 있는 경우
+            else if(deleted.contains(policy.getId())) {
+                deScorePolicyRepository.delete(policy);
+            }
+        }
+        policies.removeIf(it -> deleted.contains(it.getId()));
+
+        // 객체 생성 처리
+        for(DrawEventScorePolicyDto createdDto : createdDtos.values()) {
+            DrawEventScorePolicy policy = DrawEventScorePolicy.of(
+                    createdDto.getAction(),
+                    createdDto.getScore(),
+                    drawEvent
+            );
+            policies.add(policy);
+        }
+    }
+
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/EventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/EventFieldMapper.java
@@ -6,5 +6,7 @@ import hyundai.softeer.orange.event.dto.EventDto;
 
 public interface EventFieldMapper {
     boolean canHandle(EventType eventType);
-    void handle(EventMetadata metadata, EventDto dto);
+    void fetchToEventEntity(EventMetadata metadata, EventDto dto);
+    void fetchToDto(EventMetadata metadata, EventDto dto);
+    void editEventField(EventMetadata metadata, EventDto dto);
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
@@ -7,22 +7,27 @@ import hyundai.softeer.orange.event.common.exception.EventException;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.fcfs.FcfsEventDto;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * EventMetadata에 FcfsEvent를 주입해주는 매퍼
  */
+@RequiredArgsConstructor
 @Component
 public class FcfsEventFieldMapper implements EventFieldMapper {
+    private final FcfsEventRepository fcfsEventRepository;
     @Override
     public boolean canHandle(EventType eventType) {
         return eventType.equals(EventType.fcfs);
     }
 
     @Override
-    public void handle(EventMetadata metadata, EventDto eventDto) {
+    public void fetchToEventEntity(EventMetadata metadata, EventDto eventDto) {
         List<FcfsEventDto> fcfsDtos = eventDto.getFcfs();
         // 비어 있으면 안됨
         if (fcfsDtos == null || fcfsDtos.isEmpty()) throw new EventException(ErrorCode.INVALID_JSON);
@@ -38,5 +43,64 @@ public class FcfsEventFieldMapper implements EventFieldMapper {
         ).toList();
 
         metadata.addFcfsEvents(fcfsEventList);
+    }
+
+    @Override
+    public void fetchToDto(EventMetadata metadata, EventDto eventDto) {
+        List<FcfsEvent> fcfsEvents = metadata.getFcfsEventList();
+        List<FcfsEventDto> fcfsEventDtos = fcfsEvents.stream().map(it -> FcfsEventDto
+                .builder()
+                .id(it.getId())
+                .startTime(it.getStartTime())
+                .endTime(it.getEndTime())
+                .participantCount(it.getParticipantCount())
+                .prizeInfo(it.getPrizeInfo())
+                .build()
+        ).toList();
+        eventDto.setFcfsList(fcfsEventDtos);
+    }
+
+    @Override
+    public void editEventField(EventMetadata metadata, EventDto eventDto) {
+        List<FcfsEvent> fcfsEvents = metadata.getFcfsEventList();
+        // 집합을 이용해서 created / updated / deleted 를 구분
+        Map<Boolean, Map<Long, FcfsEventDto>> fcfsAllDtos = eventDto.getFcfs().stream()
+                .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(FcfsEventDto::getId, it-> it)));
+        // true이면 created / false이면 updated
+        Map<Long, FcfsEventDto> createdDtos = fcfsAllDtos.get(true);
+        Map<Long, FcfsEventDto> updatedDtos = fcfsAllDtos.get(false);
+
+        Set<Long> updated = new HashSet<>(updatedDtos.keySet());
+        Set<Long> deleted = fcfsEvents.stream().map(FcfsEvent::getId).collect(Collectors.toSet());
+        // null은 created
+        updated.retainAll(deleted); // dto & entity 교집합 => updated
+        deleted.removeAll(updated); // entity에는 있는데 dto에는 없음 => deleted
+        for(FcfsEvent event: fcfsEvents) {
+            // update에 있는 경우
+            if(updated.contains(event.getId())) {
+                FcfsEventDto updatedDto = updatedDtos.get(event.getId());
+                event.updateStartTime(updatedDto.getStartTime());
+                event.updateEndTime(updatedDto.getEndTime());
+                event.updateParticipantCount(updatedDto.getParticipantCount());
+                event.updatePrizeInfo(updatedDto.getPrizeInfo());
+            }
+            // delete에 있는 경우
+            else if(deleted.contains(event.getId())) {
+                fcfsEventRepository.delete(event);
+            }
+        }
+        fcfsEvents.removeIf(it -> deleted.contains(it.getId()));
+
+        // 객체 생성 처리
+        for(FcfsEventDto createdDto : createdDtos.values()) {
+            FcfsEvent newEvent = FcfsEvent.of(
+                    createdDto.getStartTime(),
+                    createdDto.getEndTime(),
+                    createdDto.getParticipantCount(),
+                    createdDto.getPrizeInfo(),
+                    metadata
+            );
+            fcfsEvents.add(newEvent);
+        }
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
@@ -5,9 +5,9 @@ import hyundai.softeer.orange.core.auth.AuthRole;
 import hyundai.softeer.orange.event.common.service.EventService;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.EventFrameCreateRequest;
+import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +38,34 @@ public class EventController {
     }
 
     @Auth({AuthRole.admin})
+    @GetMapping("/edit")
+    @Operation(summary = "이벤트 수정 초기 데이터 획득", description = "이벤트 정보 수정을 위해 초기 정보를 받는다", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트 정보를 정상적으로 받음"),
+            @ApiResponse(responseCode = "404", description = "대응되는 이벤트가 존재하지 않음")
+    })
+    public ResponseEntity<EventDto> getEventEditData(
+            @RequestParam("eventId") String eventId
+    ) {
+        EventDto eventInfo = eventService.getEventInfo(eventId);
+        return ResponseEntity.ok(eventInfo);
+    }
+
+    @Auth({AuthRole.admin})
+    @PostMapping("/edit")
+    @Operation(summary = "이벤트 수정", description = "관리자가 이벤트를 수정한다", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트 생성 성공"),
+            @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패")
+    })
+    public ResponseEntity<?> editEvent(
+            @Validated({EventEditGroup.class}) @RequestBody EventDto eventDto
+    ) {
+        eventService.editEvent(eventDto);
+        return ResponseEntity.ok().build();
+    }
+
+
+
+    @Auth({AuthRole.admin})
     @PostMapping("/frame")
     @Operation(summary = "이벤트 프레임 생성", description = "관리자가 이벤트 프레임을 새롭게 등록한다", responses = {
             @ApiResponse(responseCode = "201", description = "이벤트 프레임 생성 성공"),
@@ -47,4 +75,6 @@ public class EventController {
         eventService.createEventFrame(req.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/event")
+@RequestMapping("/api/v1/event")
 @RestController
 public class EventController {
     private final EventService eventService;

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -49,18 +49,38 @@ public class EventMetadata {
     @Column
     private EventStatus status;
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public void updateEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public void updateUrl(String url) {
+        this.url = url;
+    }
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_frame_id")
     private EventFrame eventFrame;
 
-    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST})
+    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private final List<DrawEvent> drawEventList = new ArrayList<>();
 
     public void addDrawEvent(DrawEvent drawEvent) {
         this.drawEventList.add(drawEvent);
     }
 
-    @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST})
+    @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private final List<FcfsEvent> fcfsEventList = new ArrayList<>();
 
     public void addFcfsEvents(List<FcfsEvent> fcfsEventList) {

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
@@ -4,6 +4,9 @@ import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface EventMetadataRepository extends JpaRepository<EventMetadata, Long> {
+    Optional<EventMetadata> findFirstByEventId(String eventId);
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -68,6 +68,11 @@ public class EventService {
         Optional<EventMetadata> metadataOpt = emRepository.findFirstByEventId(eventId);
         EventMetadata eventMetadata = metadataOpt
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        eventMetadata.updateName(eventDto.getName());
+        eventMetadata.updateDescription(eventDto.getDescription());
+        eventMetadata.updateStartTime(eventDto.getStartTime());
+        eventMetadata.updateEndTime(eventDto.getEndTime());
+        eventMetadata.updateUrl(eventDto.getUrl());
 
         EventFieldMapper mapper = mapperMatcher.getMapper(eventDto.getEventType());
         if(mapper == null) throw new EventException(ErrorCode.INVALID_EVENT_TYPE);

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -12,10 +12,10 @@ import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
 import hyundai.softeer.orange.event.dto.EventDto;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -81,7 +81,7 @@ public class EventService {
         emRepository.save(eventMetadata);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public EventDto getEventInfo(String eventId) {
         Optional<EventMetadata> metadataOpt = emRepository.findFirstByEventId(eventId);
         EventMetadata metadata = metadataOpt

--- a/src/main/java/hyundai/softeer/orange/event/component/EventKeyGenerator.java
+++ b/src/main/java/hyundai/softeer/orange/event/component/EventKeyGenerator.java
@@ -25,7 +25,7 @@ public class EventKeyGenerator {
     public String generate(LocalDateTime now) {
         LocalDateTime nextDay = now.plusDays(1).toLocalDate().atTime(0,0,5);
 
-        String dateInfo = formatter.format(LocalDateTime.now());
+        String dateInfo = formatter.format(now);
         String incKey = EventConst.REDIS_KEY_PREFIX + dateInfo;
 
         Long number = redisTemplate.opsForValue().increment(incKey);

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -22,10 +22,14 @@ public class DrawEvent {
     @JoinColumn(name="event_metadata_id")
     private EventMetadata eventMetadata;
 
-    @OneToMany(mappedBy ="drawEvent", cascade = {CascadeType.PERSIST})
+    @OneToMany(mappedBy ="drawEvent",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            fetch = FetchType.EAGER) // 추첨 이벤트는 항상 policy와 함께 사용되므로 EAGER로 설정
     private List<DrawEventScorePolicy> policyList = new ArrayList<>();
 
-    @OneToMany(mappedBy ="drawEvent", cascade = {CascadeType.PERSIST})
+    @OneToMany(mappedBy ="drawEvent",
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            fetch = FetchType.EAGER) // 추첨 이벤트는 항상 metadata와 함께 사용되므로 EAGER로 설정
     private List<DrawEventMetadata> metadataList = new ArrayList<>();
 
     @OneToMany(mappedBy ="drawEvent")

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventMetadata.java
@@ -23,6 +23,18 @@ public class DrawEventMetadata {
     @JoinColumn(name = "draw_event_id")
     private DrawEvent drawEvent;
 
+    public void updateGrade(Long grade) {
+        this.grade = grade;
+    }
+
+    public void updateCount(Long count) {
+        this.count = count;
+    }
+
+    public void updatePrizeInfo(String prizeInfo) {
+        this.prizeInfo = prizeInfo;
+    }
+
     public static DrawEventMetadata of(Long grade, Long count, String prizeInfo, DrawEvent drawEvent) {
         DrawEventMetadata metadata = new DrawEventMetadata();
         metadata.grade = grade;

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventScorePolicy.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventScorePolicy.java
@@ -14,13 +14,20 @@ public class DrawEventScorePolicy {
     @Column
     private DrawEventAction action;
 
-
     @Column
     private Integer score;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "draw_event_id")
     private DrawEvent drawEvent;
+
+    public void updateAction(DrawEventAction action) {
+        this.action = action;
+    }
+
+    public void updateScore(Integer score) {
+        this.score = score;
+    }
 
     public static DrawEventScorePolicy of(DrawEventAction action, Integer score, DrawEvent drawEvent) {
         DrawEventScorePolicy policy = new DrawEventScorePolicy();

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
@@ -1,9 +1,11 @@
 package hyundai.softeer.orange.event.draw.repository;
 
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface DrawEventRepository extends JpaRepository<DrawEvent, Long> {
-}
+public interface DrawEventRepository extends JpaRepository<DrawEvent, Long> { }

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
@@ -8,11 +8,17 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class EventDto {
     @NotNull(groups = {EventEditGroup.class})
@@ -46,4 +52,12 @@ public class EventDto {
 
     @Valid
     private DrawEventDto draw;
+
+    public void setDraw(DrawEventDto drawEventDto) {
+        this.draw = drawEventDto;
+    }
+
+    public void setFcfsList(List<FcfsEventDto> fcfsEventDtos) {
+        this.fcfs = fcfsEventDtos;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventDto.java
@@ -3,14 +3,16 @@ package hyundai.softeer.orange.event.dto.draw;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.List;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
+@Setter
 public class DrawEventDto {
-
-    @NotNull(groups = {EventEditGroup.class})
     private Long id;
 
     @NotNull

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
@@ -2,11 +2,13 @@ package hyundai.softeer.orange.event.dto.draw;
 
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import lombok.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class DrawEventMetadataDto {
-    @NotNull(groups = {EventEditGroup.class})
     private Long id;
 
     @NotNull

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
@@ -4,11 +4,13 @@ import hyundai.softeer.orange.event.draw.enums.DrawEventAction;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import lombok.*;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class DrawEventScorePolicyDto {
-    @NotNull(groups = {EventEditGroup.class})
     private Long id;
 
     @NotNull

--- a/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
@@ -1,15 +1,20 @@
 package hyundai.softeer.orange.event.dto.fcfs;
 
-import hyundai.softeer.orange.event.dto.group.EventCreateGroup;
+import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Builder
+@RequiredArgsConstructor
+@AllArgsConstructor
 @Getter
 public class FcfsEventDto {
-    @NotNull(groups = {EventCreateGroup.class})
     private Long id;
 
     @NotNull

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
@@ -38,6 +38,22 @@ public class FcfsEvent {
     @JoinColumn(name = "event_metadata_id")
     private EventMetadata eventMetaData;
 
+    public void updateStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public void updateEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public void updateParticipantCount(Long participantCount) {
+        this.participantCount = participantCount;
+    }
+
+    public void updatePrizeInfo(String prizeInfo) {
+        this.prizeInfo = prizeInfo;
+    }
+
     @OneToMany(mappedBy = "fcfsEvent")
     private final List<FcfsEventWinningInfo> infos = new ArrayList<>();
 

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/EventFieldMapperMatcherTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/EventFieldMapperMatcherTest.java
@@ -3,12 +3,15 @@ package hyundai.softeer.orange.event.common.component.eventFieldMapper;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper.DrawEventFieldMapper;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper.EventFieldMapper;
 import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.draw.repository.DrawEventMetadataRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventScorePolicyRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class EventFieldMapperMatcherTest {
     @DisplayName("이벤트 타입에 대응되는 매퍼가 있다면 반환한다. 없다면 null을 반환한다.")
@@ -16,7 +19,10 @@ class EventFieldMapperMatcherTest {
     void returnMapperIfExistElseNull() {
         EventType existType = EventType.draw;
         EventType notExistType = EventType.fcfs;
-        List<EventFieldMapper> mappers = List.of(new DrawEventFieldMapper());
+        DrawEventMetadataRepository repo1 = mock(DrawEventMetadataRepository.class);
+        DrawEventScorePolicyRepository repo2 = mock(DrawEventScorePolicyRepository.class);
+
+        List<EventFieldMapper> mappers = List.of(new DrawEventFieldMapper(repo1, repo2));
         EventFieldMapperMatcher mapperMatcher = new EventFieldMapperMatcher(mappers);
 
         var mapper1 = mapperMatcher.getMapper(existType);

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
@@ -2,11 +2,12 @@ package hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper;
 
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.enums.EventType;
-import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventMetadataDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventScorePolicyDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 class DrawEventFieldMapperTest {
-    DrawEventFieldMapper mapper = new DrawEventFieldMapper();
+    DrawEventFieldMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new DrawEventFieldMapper(null, null);
+    }
+
 
     @DisplayName("canHandle은 해당 타입을 지원하는지 여부를 반환한다.")
     @Test
@@ -37,7 +44,7 @@ class DrawEventFieldMapperTest {
         EventDto dto1 = new EventDto(); // drawDto 없음
 
         assertThatThrownBy(() -> {
-            mapper.handle(metadata, dto1);
+            mapper.fetchToEventEntity(metadata, dto1);
         });
     }
 
@@ -52,7 +59,7 @@ class DrawEventFieldMapperTest {
         when(drawEventDto.getMetadata()).thenReturn(List.of(new DrawEventMetadataDto()));
         when(drawEventDto.getPolicies()).thenReturn(List.of(new DrawEventScorePolicyDto()));
 
-        mapper.handle(metadata, dto);
+        mapper.fetchToEventEntity(metadata, dto);
 
         var drawEvents = metadata.getDrawEventList();
         var drawEvent = drawEvents.get(0);

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
@@ -2,7 +2,8 @@ package hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper;
 
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.enums.EventType;
-import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventMetadataRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventScorePolicyRepository;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventMetadataDto;
@@ -10,6 +11,9 @@ import hyundai.softeer.orange.event.dto.draw.DrawEventScorePolicyDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.List;
 
@@ -18,12 +22,18 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@DataJpaTest
+@TestPropertySource(locations = "classpath:application-test.yml")
 class DrawEventFieldMapperTest {
+    @Autowired
+    DrawEventMetadataRepository drawEventMetadataRepository;
+    @Autowired
+    DrawEventScorePolicyRepository drawEventScorePolicyRepository;
     DrawEventFieldMapper mapper;
 
     @BeforeEach
     void setUp() {
-        mapper = new DrawEventFieldMapper(null, null);
+        mapper = new DrawEventFieldMapper(drawEventMetadataRepository, drawEventScorePolicyRepository);
     }
 
 
@@ -39,7 +49,7 @@ class DrawEventFieldMapperTest {
 
     @DisplayName("EventDto에 draw 필드가 없으면 예외가 터진다.")
     @Test
-    void throwErrorIfFcfsDtoNotExists() {
+    void fetchToEventEntity_throwErrorIfFcfsDtoNotExists() {
         EventMetadata metadata = new EventMetadata();
         EventDto dto1 = new EventDto(); // drawDto 없음
 
@@ -51,7 +61,7 @@ class DrawEventFieldMapperTest {
 
     @DisplayName("정상적인 EventDto가 들어오면 정상적으로 관계를 설정한다.")
     @Test
-    void setRelationIfEventDtoIsValid() {
+    void fetchToEventEntity_setRelationIfEventDtoIsValid() {
         EventMetadata metadata = new EventMetadata();
         EventDto dto = mock(EventDto.class);
         DrawEventDto drawEventDto = mock(DrawEventDto.class);
@@ -75,4 +85,23 @@ class DrawEventFieldMapperTest {
         assertThat(oneDrawMetadata.getDrawEvent()).isSameAs(drawEvent);
         assertThat(oneEventPolicy.getDrawEvent()).isSameAs(drawEvent);
     }
+
+    @DisplayName("draw 이벤트가 없으면 예외가 발생한다.")
+    @Test
+    void editEventField_throwIfDrawEventNotExists() {
+        EventMetadata metadata = new EventMetadata();
+        EventDto dto = mock(EventDto.class);
+        assertThatThrownBy(() -> {
+            mapper.editEventField(metadata, dto);
+        });
+    }
+
+    // TODO: repository 통합 테스트 코드 작성
+//    @DisplayName("규칙에 따라 정상적으로 DrawEvent를 갱신해야 한다.")
+//    @Test
+//    void editEventField_testOpIsValid() {
+//        // 1. DrawEvent
+//        EventMetadata metadata = new EventMetadata();
+//        EventDto dto = new EventDto();
+//    }
 }

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapperTest.java
@@ -5,20 +5,25 @@ import hyundai.softeer.orange.event.common.enums.EventType;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.fcfs.FcfsEventDto;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEvent;
-import org.assertj.core.api.Assertions;
+import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class FcfsEventFieldMapperTest {
-    FcfsEventFieldMapper mapper = new FcfsEventFieldMapper();
+
+    FcfsEventFieldMapper mapper;
+    @BeforeEach
+    void setUp() {
+        FcfsEventRepository repo = mock(FcfsEventRepository.class);
+        mapper = new FcfsEventFieldMapper(repo);
+    }
 
     @DisplayName("canHandle은 해당 타입을 지원하는지 여부를 반환한다.")
     @Test
@@ -39,11 +44,11 @@ class FcfsEventFieldMapperTest {
         when(dto2.getFcfs()).thenReturn(List.of());
 
         assertThatThrownBy(() -> {
-            mapper.handle(metadata, dto1);
+            mapper.fetchToEventEntity(metadata, dto1);
         });
 
         assertThatThrownBy(() -> {
-            mapper.handle(metadata, dto2);
+            mapper.fetchToEventEntity(metadata, dto2);
         });
     }
 
@@ -58,7 +63,7 @@ class FcfsEventFieldMapperTest {
         );
         when(dto.getFcfs()).thenReturn(dtos);
 
-        mapper.handle(metadata, dto);
+        mapper.fetchToEventEntity(metadata, dto);
 
         List<FcfsEvent> fcfsEvents = metadata.getFcfsEventList();
 

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -2,7 +2,6 @@ package hyundai.softeer.orange.event.common.service;
 
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.EventFieldMapperMatcher;
-import hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper.EventFieldMapper;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper.FcfsEventFieldMapper;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
@@ -12,17 +11,14 @@ import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
 import hyundai.softeer.orange.event.dto.EventDto;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -46,7 +42,7 @@ class EventServiceTest {
     @DisplayName("대응되는 eventframe이 없으면 예외 반환")
     @Test
     void createEvent_throwErrorIFNoMatchedEventFrame() {
-        EventDto eventDto = new EventDto();
+        EventDto eventDto = EventDto.builder().build();
 
         assertThatThrownBy(() -> {
             eventService.createEvent(eventDto);


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #28

# 📝 작업 내용

## 이벤트 수정 로직 선택

프론트엔드 팀원과의 논의에 따라 이벤트 수정 기능을 "요청 - db 스냅샷 비교" 방식 기반으로 구현했습니다.

관리자 수정 기능을 구현하는 방법은 큰 그림에서는 2가지 방법 존재합니다.

1. fcfs event / draw event 등을 각 api를 호출하여 변경할 수 있도록 구현
2. 이벤트 관련 정보를 단일 api로 변경할 수 있도록 구현

1번의 경우 클라이언트 측에서 api를 여러 번 호출하는 것이 불편하다는 의견이 있어 2번 방식으로 구현하기로 했습니다.

단일 api를 이용하여 백엔드가 수정 기능을 만드는 법은 2가지를 생각했습니다.

1. status 플래그를 둬서 각 행의 상태를 식별할 수 있게 하고, 서버 측에서는 해당 플래그를 기반으로 갱신한다.
2. 서버 측 스냅샷(db)와 비교해서 차이를 기반으로 create / update / delete을 식별해서 갱신한다.

프론트엔드 측에서는 1번 방안보다 2번 방안이 좀 더 편리하다고 하여 2번 방안을 구현해보기로 했습니다.

구현 논리: dto(클라이언트 측 데이터) 와 entity(서버 측 데이터, 스냅샷)에 대해 set 논리를 도입하여 create / update / delete 대상이 되는 데이터를 식별하여 처리합니다.

1. create: 프론트엔드에서 전달된 id가 있는 데이터는 업데이트 된 것으로 간주
2. update: 프론트엔드에서 전달된 id가 없는 데이터는 추가되는 것으로 간주
3. delete: 프론트엔드에서 전달되지 않은 데이터는 삭제된 것으로 간주

![image](https://github.com/user-attachments/assets/e97ef4a0-dd4c-4b38-bf71-6221dd4e2a0f)

필요 이상으로 갱신 난이도가 복잡해질 경우, 이벤트 데이터를 완전 delete 후 다시 얻는 방식도 고려하고 있습니다.

## EventFieldMapper 확장 기반으로 기능 구현

이전에 event 타입 확장에 대응하기 위해 구현한 EventTypeMapper의 인터페이스를 확장, 2개 기능을 구현했습니다. 선착순, 추첨 이벤트 모두 구현한 상태입니다.

1. get / 이벤트 edit을 위한 초기 데이터 제공: 이벤트에 대한 현재 데이터를 제공합니다. 해당 데이터를 기반으로 수정을 진행합니다.
2. post / 이벤트 edit 기능:  dto - entity 스냅샷 비교 논리를 기반으로 수정 기능을 구현했습니다.