### PR TITLE
[feat] 관리자 이벤트 댓글 조회 & 삭제 (#37) 

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -1,0 +1,51 @@
+package hyundai.softeer.orange.admin.controller;
+import hyundai.softeer.orange.comment.dto.DeleteCommentsDto;
+import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
+import hyundai.softeer.orange.comment.service.CommentService;
+import hyundai.softeer.orange.core.auth.Auth;
+import hyundai.softeer.orange.core.auth.AuthRole;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/admin/comments")
+@RequiredArgsConstructor
+@RestController
+@Auth({AuthRole.admin})
+public class AdminCommentController {
+    private final CommentService commentService;
+
+    /**
+     * @param eventId 댓글을 검색할 이벤트 id
+     * @param page 댓글 페이지. default = 0
+     * @param size 한번에 읽어 올 댓글 개수. default = 10
+     * @return 대상 이벤트에 대해 검색된 댓글 목록
+     */
+    @Operation(summary = "관리자가 이벤트에 대한 댓글 목록 조회", description = "이벤트에 대한 댓글 목록을 조회한다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트에 대한 댓글 목록 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<ResponseCommentsDto> findEventComments(
+            @RequestParam String eventId,
+            @RequestParam(required = false, defaultValue = "0") Integer page,
+            @RequestParam(required = false, defaultValue = "10") Integer size
+    ) {
+         var comments = commentService.searchComments(eventId, page, size);
+         return ResponseEntity.ok(comments);
+    }
+
+    @Operation(summary = "관리가 댓글 목록 삭제", description = "관리자가 이벤트에 대한 댓글 목록을 삭제한다.", responses = {
+            @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
+    })
+    @DeleteMapping
+    public ResponseEntity<Void> deleteEventComments(@Valid @RequestBody DeleteCommentsDto dto) {
+        commentService.deleteComments(dto.getCommentIds());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/comment/dto/DeleteCommentsDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/DeleteCommentsDto.java
@@ -1,0 +1,16 @@
+package hyundai.softeer.orange.comment.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DeleteCommentsDto {
+    @NotNull
+    private List<Long> commentIds;
+
+    public DeleteCommentsDto(List<Long> commentIds) {
+        this.commentIds = commentIds;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package hyundai.softeer.orange.comment.repository;
 
 import hyundai.softeer.orange.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,4 +18,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인
     @Query(value = "SELECT COUNT(*) FROM comment WHERE event_user_id = :eventUserId AND DATE(createdAt) = CURDATE()", nativeQuery = true)
     boolean existsByCreatedDateAndEventUser(@Param("eventUserId") Long eventUserId);
+
+    @Query(value = "SELECT c.* FROM comment c " +
+            "JOIN event_frame ef ON c.event_frame_id = ef.id " +
+            "JOIN event_metadata e ON ef.id = e.event_frame_id " +
+            "WHERE e.event_id = :eventId",
+            countProjection = "c.id", // 어떤 값으로 count 셀건지 지정. 지정 안하면 count(c.*)가 되어 문제 발생.
+            nativeQuery = true)
+    Page<Comment> findAllByEventId(@Param("eventId") String eventId, Pageable pageable);
 }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -15,6 +15,7 @@ import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,7 +25,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class CommentService {
-
     private final CommentRepository commentRepository;
     private final EventFrameRepository eventFrameRepository;
     private final EventUserRepository eventUserRepository;
@@ -67,5 +67,18 @@ public class CommentService {
 
         commentRepository.deleteById(commentId);
         return commentId;
+    }
+
+    @Transactional
+    public void deleteComments(List<Long> commentIds) {
+        commentRepository.deleteAllById(commentIds);
+    }
+
+    public ResponseCommentsDto searchComments(String eventId, Integer page, Integer size) {
+        PageRequest pageInfo = PageRequest.of(page, size);
+
+        var comments = commentRepository.findAllByEventId(eventId,pageInfo)
+                .getContent().stream().map(ResponseCommentDto::from).toList();
+        return new ResponseCommentsDto(comments);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
+++ b/src/main/java/hyundai/softeer/orange/common/GlobalExceptionHandler.java
@@ -10,10 +10,12 @@ import hyundai.softeer.orange.eventuser.exception.EventUserException;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,6 +33,15 @@ public class GlobalExceptionHandler {
             String errorMessage = error.getDefaultMessage();
             errors.put(fieldName, errorMessage);
         });
+        return ResponseEntity.badRequest().body(errors);
+    }
+
+    // TODO: messages.properties에 예외 메시지 커스터마이징할 수 있게 방법 찾아보기
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Map<String, String>> handleInValidRequestException(MethodArgumentTypeMismatchException e) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put(e.getName(), e.getLocalizedMessage());
         return ResponseEntity.badRequest().body(errors);
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
@@ -2,10 +2,12 @@ package hyundai.softeer.orange.event.common.controller;
 
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.service.EventService;
 import hyundai.softeer.orange.event.dto.BriefEventDto;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.EventFrameCreateRequest;
+import hyundai.softeer.orange.event.dto.EventSearchHintDto;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -110,5 +112,14 @@ public class EventController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @Auth({AuthRole.admin})
+    @GetMapping("/hints")
+    @Operation(summary="이벤트 힌트 목록 얻기", description = "관리자가 이벤트 댓글 열람을 위해 검색할 때 반환하는 (이벤트 id / 이름 ) 정보 목록을 얻는다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트 힌트 목록 획득")
+    })
+    public ResponseEntity<List<EventSearchHintDto>> findEventSearchHints(@RequestParam("search") String search) {
+        var searchHints = eventService.searchHints(search);
+        return ResponseEntity.ok(searchHints);
+    }
 
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
@@ -8,8 +8,6 @@ import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.EventFrameCreateRequest;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/EventController.java
@@ -49,7 +49,8 @@ public class EventController {
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String sort,
             @RequestParam(required = false) Integer page,
-            @RequestParam(required = false) Integer size) {
+            @RequestParam(required = false) Integer size
+    ) {
         List<BriefEventDto> events = eventService.searchEvents(search, sort, page, size);
         return ResponseEntity.ok(events);
     }

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
@@ -2,7 +2,6 @@ package hyundai.softeer.orange.event.common.repository;
 
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.enums.EventType;
-import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
 
 public class EventSpecification {
@@ -13,8 +12,8 @@ public class EventSpecification {
 
     public static Specification<EventMetadata> searchOnName(String search, boolean conjunctionOnNull) {
         return (metadata, query, cb) -> {
-            if (search == null || search.isEmpty()) return conjunctionOnNull ? cb.conjunction() : cb.disjunction();
-            return cb.like(metadata.get("eventId"), "%" + search + "%");
+            if (search == null || search.isEmpty()) return (conjunctionOnNull ? cb.conjunction() : cb.disjunction());
+            return cb.like(metadata.get("name"), "%" + search + "%");
         };
     }
 
@@ -24,10 +23,11 @@ public class EventSpecification {
 
     public static Specification<EventMetadata> searchOnEventId(String search,  boolean conjunctionOnNull) {
         return (metadata, query, cb) -> {
-            if (search == null || search.isEmpty()) return conjunctionOnNull ? cb.conjunction() : cb.disjunction();
+            if (search == null || search.isEmpty()) return (conjunctionOnNull ? cb.conjunction() : cb.disjunction());
             return cb.like(metadata.get("eventId"), "%" + search + "%");
         };
     }
+
     public static Specification<EventMetadata> isEventTypeOf(EventType eventType) {
         return (metadata, query, cb) -> cb.equal(metadata.get("eventType"), eventType);
     }

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
@@ -1,17 +1,34 @@
 package hyundai.softeer.orange.event.common.repository;
 
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
 import jakarta.persistence.criteria.Predicate;
 import org.springframework.data.jpa.domain.Specification;
 
 public class EventSpecification {
-    public static Specification<EventMetadata> withSearch(String search) {
-        return (metadata, query, cb) -> {
-            if (search == null || search.isEmpty()) return cb.conjunction();
 
-            Predicate searchName = cb.like(metadata.get("name"), "%" + search + "%");
-            Predicate searchEventId = cb.like(metadata.get("eventId"), "%" + search + "%");
-            return cb.or(searchName, searchEventId);
+    public static Specification<EventMetadata> searchOnName(String search) {
+        return searchOnName(search, true);
+    }
+
+    public static Specification<EventMetadata> searchOnName(String search, boolean conjunctionOnNull) {
+        return (metadata, query, cb) -> {
+            if (search == null || search.isEmpty()) return conjunctionOnNull ? cb.conjunction() : cb.disjunction();
+            return cb.like(metadata.get("eventId"), "%" + search + "%");
         };
+    }
+
+    public static Specification<EventMetadata> searchOnEventId(String search) {
+        return searchOnEventId(search, true);
+    }
+
+    public static Specification<EventMetadata> searchOnEventId(String search,  boolean conjunctionOnNull) {
+        return (metadata, query, cb) -> {
+            if (search == null || search.isEmpty()) return conjunctionOnNull ? cb.conjunction() : cb.disjunction();
+            return cb.like(metadata.get("eventId"), "%" + search + "%");
+        };
+    }
+    public static Specification<EventMetadata> isEventTypeOf(EventType eventType) {
+        return (metadata, query, cb) -> cb.equal(metadata.get("eventType"), eventType);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -33,5 +33,9 @@ public class DrawEvent {
     private List<DrawEventMetadata> metadataList = new ArrayList<>();
 
     @OneToMany(mappedBy ="drawEvent")
+    private List<EventParticipationInfo> participationInfoList = new ArrayList<>();
+
+
+    @OneToMany(mappedBy ="drawEvent")
     private List<DrawEventWinningInfo> winningInfoList = new ArrayList<>();
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/BriefEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/BriefEventDto.java
@@ -8,39 +8,28 @@ import java.time.LocalDateTime;
 /**
  * 이벤트 리스트를 위한 정보만 담고 있는 객체
  */
-@Getter
-public class BriefEventDto {
+public interface BriefEventDto {
     /**
      * HD000000_000 형식으로 구성된 id 값
      */
-    String eventId;
+    String getEventId();
     /**
      * 이벤트의 이름
      */
-    private String name;
+    String getName();
 
     /**
      * 이벤트 시작 시간
      */
-    private LocalDateTime startTime;
+    LocalDateTime getStartTime();
 
     /**
      * 이벤트 종료 시간
      */
-    private LocalDateTime endTime;
+    LocalDateTime getEndTime();
 
     /**
      * 이벤트의 타입
      */
-    private EventType eventType;
-
-    public static BriefEventDto of(String eventId, String name, LocalDateTime startTime, LocalDateTime endTime, EventType eventType) {
-        BriefEventDto briefEventDto = new BriefEventDto();
-        briefEventDto.eventId = eventId;
-        briefEventDto.name = name;
-        briefEventDto.startTime = startTime;
-        briefEventDto.endTime = endTime;
-        briefEventDto.eventType = eventType;
-        return briefEventDto;
-    }
+    EventType getEventType();
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventSearchHintDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventSearchHintDto.java
@@ -5,15 +5,7 @@ import lombok.Getter;
 /**
  * 관리자가 이벤트 댓글 검색 시 자동완성 영역에 제공되는 데이터
  */
-@Getter
-public class EventSearchHintDto {
-    private String eventId;
-    private String name;
-
-    public static EventSearchHintDto of(String eventId, String name) {
-        EventSearchHintDto dto = new EventSearchHintDto();
-        dto.eventId = eventId;
-        dto.name = name;
-        return dto;
-    }
+public interface EventSearchHintDto {
+    String getEventId();
+    String getName();
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventSearchHintDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventSearchHintDto.java
@@ -1,0 +1,19 @@
+package hyundai.softeer.orange.event.dto;
+
+import lombok.Getter;
+
+/**
+ * 관리자가 이벤트 댓글 검색 시 자동완성 영역에 제공되는 데이터
+ */
+@Getter
+public class EventSearchHintDto {
+    private String eventId;
+    private String name;
+
+    public static EventSearchHintDto of(String eventId, String name) {
+        EventSearchHintDto dto = new EventSearchHintDto();
+        dto.eventId = eventId;
+        dto.name = name;
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.eventuser.entity;
 import hyundai.softeer.orange.comment.entity.Comment;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.draw.entity.DrawEventWinningInfo;
+import hyundai.softeer.orange.event.draw.entity.EventParticipationInfo;
 import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -39,6 +40,9 @@ public class EventUser {
 
     @OneToMany(mappedBy = "eventUser")
     private List<Comment> commentList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "eventUser")
+    private List<EventParticipationInfo> participationInfoList  = new ArrayList<>();
 
     @OneToMany(mappedBy = "eventUser")
     private List<DrawEventWinningInfo> drawEventWinningInfoList = new ArrayList<>();

--- a/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
@@ -12,6 +12,8 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @TestPropertySource(locations = "classpath:application-test.yml")
@@ -48,14 +50,16 @@ class EventSpecificationTest {
         emRepository.save(em3);
 
         Specification<EventMetadata> spec = EventSpecification.searchOnName(null);
+        Specification<EventMetadata> spec2 = EventSpecification.searchOnEventId(null);
 
-        Page<EventMetadata> result = emRepository.findAll(spec, PageRequest.of(0,100));
+        Page<EventMetadata> result = emRepository.findAll(spec.or(spec2), PageRequest.of(0,100));
         assertThat(result.getTotalElements()).isEqualTo(3);
     }
 
     @DisplayName("search가 있으면 필터링 수행")
     @Test
     void searchWithSearchClause() {
+        String search = "event";
         EventFrame ef = EventFrame.of("test");
         efRepository.save(ef);
         // event 포함 ( name )
@@ -85,13 +89,13 @@ class EventSpecificationTest {
                 .name("not included")
                 .eventFrame(ef)
                 .build();
-        emRepository.save(em1);
-        emRepository.save(em2);
-        emRepository.save(em3);
+        emRepository.saveAll(List.of(em1, em2, em3, em4));
 
-        Specification<EventMetadata> spec = EventSpecification.searchOnName("event");
+        Specification<EventMetadata> spec1 = EventSpecification.searchOnName(search);
+        Specification<EventMetadata> spec2 = EventSpecification.searchOnEventId(search);
 
-        Page<EventMetadata> result = emRepository.findAll(spec, PageRequest.of(0,100));
+        Page<EventMetadata> result = emRepository.findAll(spec1.or(spec2), PageRequest.of(0,100));
+
         assertThat(result.getTotalElements()).isEqualTo(3);
     }
 }

--- a/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
@@ -47,7 +47,7 @@ class EventSpecificationTest {
         emRepository.save(em2);
         emRepository.save(em3);
 
-        Specification<EventMetadata> spec = EventSpecification.withSearch(null);
+        Specification<EventMetadata> spec = EventSpecification.searchOnName(null);
 
         Page<EventMetadata> result = emRepository.findAll(spec, PageRequest.of(0,100));
         assertThat(result.getTotalElements()).isEqualTo(3);
@@ -89,7 +89,7 @@ class EventSpecificationTest {
         emRepository.save(em2);
         emRepository.save(em3);
 
-        Specification<EventMetadata> spec = EventSpecification.withSearch("event");
+        Specification<EventMetadata> spec = EventSpecification.searchOnName("event");
 
         Page<EventMetadata> result = emRepository.findAll(spec, PageRequest.of(0,100));
         assertThat(result.getTotalElements()).isEqualTo(3);

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -146,7 +146,6 @@ public class EventServiceSearchEventsTest {
     @DisplayName("여러 옵션 함께 사용도 가능")
     @Test
     void searchEvents_withMultipleOptions() {
-
         var list = eventService.searchEvents("25", "endTime:desc", 1, 1);
         BriefEventDto target = list.get(0);
 

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -86,12 +87,7 @@ public class EventServiceSearchEventsTest {
                 .eventFrame(ef)
                 .build();
 
-        emRepo.save(em1);
-        emRepo.save(em2);
-        emRepo.save(em3);
-        emRepo.save(em4);
-        emRepo.save(em5);
-        emRepo.save(em6);
+        emRepo.saveAll(List.of(em1,em2,em3,em4,em5,em6));
     }
 
     @DisplayName("search 없으면 모두 출력")

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
@@ -1,0 +1,116 @@
+package hyundai.softeer.orange.event.common.service;
+
+import hyundai.softeer.orange.event.common.component.eventFieldMapper.EventFieldMapperMatcher;
+import hyundai.softeer.orange.event.common.entity.EventFrame;
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
+import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
+import hyundai.softeer.orange.event.component.EventKeyGenerator;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@DataJpaTest
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class EventServiceSearchHintsTest {
+    @Autowired
+    private EventMetadataRepository emRepo;
+    @Autowired
+    private EventFrameRepository efRepo;
+
+    private EventFieldMapperMatcher mapperMatcher;
+    private EventKeyGenerator keyGenerator;
+    private EventService eventService;
+
+    @BeforeEach
+    public void setUp() {
+        mapperMatcher = mock(EventFieldMapperMatcher.class);
+        keyGenerator = mock(EventKeyGenerator.class);
+        eventService = new EventService(efRepo, emRepo, mapperMatcher, keyGenerator);
+        // 이벤트 프레임 생성
+        EventFrame ef = EventFrame.of("test");
+        efRepo.save(ef);
+
+        // 이벤트 메타데이터 생성
+        EventMetadata em1 = EventMetadata.builder()
+                .eventId("HD240805_001")
+                .name("hyundai car event")
+                .startTime(LocalDateTime.of(2024,8,1,15,0))
+                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .eventFrame(ef)
+                .eventType(EventType.draw)
+                .build();
+
+        EventMetadata em2 = EventMetadata.builder()
+                .eventId("HD240905_002")
+                .name("hyundai car event")
+                .startTime(LocalDateTime.of(2024,8,1,15,0))
+                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .eventFrame(ef)
+                .eventType(EventType.draw)
+                .build();
+
+        EventMetadata em3 = EventMetadata.builder()
+                .eventId("HD240805_003")
+                .name("hyundai car event")
+                .startTime(LocalDateTime.of(2024,8,1,15,0))
+                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .eventFrame(ef)
+                .eventType(EventType.fcfs)
+                .build();
+
+        // 이벤트 프레임 리스트 등록
+        emRepo.saveAll(List.of(em1, em2, em3));
+    }
+
+    @DisplayName("검색어가 없으면 아무 것도 반환 안함")
+    @Test
+    void searchHints_NoReturnIfNoSearch() {
+
+        var hints = eventService.searchHints(null);
+        assertThat(hints).isEmpty();
+    }
+
+    @DisplayName("검색어가 있더라도 매칭되는 값 없으면 반환 안함")
+    @Test
+    void searchHints_NoReturnIfNoMatchedToSearch() {
+        String search = "NotMatch";
+        var hints = eventService.searchHints(search);
+        assertThat(hints).isEmpty();
+    }
+
+
+    @DisplayName("추첨 이벤트만 매칭됨")
+    @Test
+    void searchHints_MatchOnlyDrawEvent() {
+        String search = "240805";
+        var hints = eventService.searchHints(search);
+        assertThat(hints).hasSize(1);
+        assertThat(hints.get(0).getEventId()).isEqualTo("HD240805_001");
+    }
+
+    @DisplayName("검색어에 따라 매칭되는 이벤트 목록이 달라짐")
+    @Test
+    void searchHints_MatchVariousBySearch() {
+        String search1 = "240";
+        var hints1 = eventService.searchHints(search1);
+        assertThat(hints1).hasSize(2);
+
+        String search2 = "2409";
+        var hints2 = eventService.searchHints(search2);
+        assertThat(hints2).hasSize(1);
+
+    }
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #37

# 📝 작업 내용

1. 이벤트 이름 자동완성을 위한 검색 기능
2. 이벤트 댓글 조회 기능
3. 이벤트 댓글 페이징 기능
4. 이벤트 댓글 삭제 기능

## 이슈
이전 feature을 구현할 당시에는 Spring Specification으로 동적 쿼리를 구현하기에 충분하다고 생각했습니다. 그런데, 사용하다보니 Spring Specification만으로는 DB에서 특정 열의 값만 가져오는 Projection 기능을 현재 시점에서는 구현할 수 없다는 것을 알게 되었습니다.

현재 프로젝트에서 EventMetadata은 이벤트와 관련된 메타데이터 정보를 포함하고 있습니다. 이때, 이벤트 자동완성 / 이벤트 목록 조회 시에는 이벤트 메타데이터의 일부분 데이터만 필요하므로, 모든 데이터를 fetch 하는 것은 db 측면에서 비효율적입니다. 이때 Spring Specification을 사용하는 경우 Projection을 수행하더라도 전체 데이터를 가져오는 방식으로 동작하고 있어 비효율적입니다. 관련 링크를 첨부합니다.

[이슈 링크](https://github.com/spring-projects/spring-data-jpa/issues/1524)

위와 같은 문제로 인해 크게 2가지 방법을 고민하고 있습니다.

1. queryDSL 등 동적 쿼리가 가능한 방법 도입
2. jpa criteria query 방식과 조합, 커스텀 db 구현

 전반적인 개발이 기간 내에 완료되면 이 부분을 보강해 볼 예정입니다.