### PR TITLE
[fix] 선착순 이벤트 코드 수정 (#41)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
@@ -13,4 +13,6 @@ public interface FcfsEventWinningInfoRepository extends JpaRepository<FcfsEventW
     // Fetch Join으로 eventUser 정보까지 한번에 가져와서 N+1 문제 방지
     @Query("select f from FcfsEventWinningInfo f join fetch f.eventUser where f.fcfsEvent.id = :eventSequence")
     List<FcfsEventWinningInfo> findByFcfsEventId(Long eventSequence);
+
+    boolean existsByEventUserIdAndFcfsEventId(Long eventUserId, Long fcfsEventId);
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -6,10 +6,12 @@ import hyundai.softeer.orange.event.fcfs.entity.FcfsEventWinningInfo;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
 import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
 import hyundai.softeer.orange.event.fcfs.repository.FcfsEventWinningInfoRepository;
+import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,33 +25,51 @@ public class DbFcfsService implements FcfsService{
     private final FcfsEventRepository fcfsEventRepository;
     private final EventUserRepository eventUserRepository;
     private final FcfsEventWinningInfoRepository fcfsEventWinningInfoRepository;
+    private final RedisTemplate<String, Boolean> booleanRedisTemplate;
 
     @Override
     @Transactional
     public boolean participate(Long eventSequence, String userId){
+        // 이벤트 종료 여부 확인
+        if (isEventEnded(eventSequence)) {
+            return false;
+        }
+
+        // 비관적 락을 통해 동시성 제어
         FcfsEvent fcfsEvent = fcfsEventRepository.findByIdWithLock(eventSequence)
                 .orElseThrow(() -> new FcfsEventException(ErrorCode.EVENT_NOT_FOUND));
         EventUser eventUser = eventUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new FcfsEventException(ErrorCode.EVENT_USER_NOT_FOUND));
-        // 이미 마감된 이벤트인지 확인
-        if(fcfsEvent.getInfos().size() >= fcfsEvent.getParticipantCount()){
-            return false;
-        }
-        validateParticipate(fcfsEvent, eventUser);
 
-        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser));
-        return true;
-    }
-
-    private void validateParticipate(FcfsEvent fcfsEvent, EventUser eventUser){
         // 잘못된 이벤트 참여 시간인지 검증
         if(LocalDateTime.now().isBefore(fcfsEvent.getStartTime()) || LocalDateTime.now().isAfter(fcfsEvent.getEndTime())){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 
-        // 이미 당첨된 사용자인지 확인
-        if(fcfsEvent.getInfos().stream().anyMatch(info -> info.getEventUser().equals(eventUser))){
-            throw new FcfsEventException(ErrorCode.ALREADY_WINNER);
+        // 이미 이 이벤트에 참여했는지 확인
+        if(isParticipated(eventUser.getId(), eventSequence)){
+            throw new FcfsEventException(ErrorCode.ALREADY_PARTICIPATED);
         }
+
+        // 인원 수 초과 시 종료 flag 설정
+        if(fcfsEvent.getInfos().size() >= fcfsEvent.getParticipantCount()){
+            endEvent(eventSequence);
+            return false;
+        }
+
+        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser));
+        return true;
+    }
+
+    private boolean isParticipated(Long userId, Long eventSequence){
+        return fcfsEventWinningInfoRepository.existsByEventUserIdAndFcfsEventId(userId, eventSequence);
+    }
+
+    private boolean isEventEnded(Long eventSequence){
+        return Boolean.TRUE.equals((booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(eventSequence.toString()))));
+    }
+
+    private void endEvent(Long eventSequence){
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), true);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
@@ -65,6 +65,10 @@ public class RedisSetFcfsService implements FcfsService {
 
     // 인원수 마감 여부를 확인하며, synchronized를 통해 동시성 제어
     private synchronized boolean isEventFull(Long eventSequence) {
+        if(isEventEnded(eventSequence)){
+            return true;
+        }
+
         Long nowCount = stringRedisTemplate.opsForZSet().size(FcfsUtil.winnerFormatting(eventSequence.toString()));
         if(nowCount == null){
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/load/DbFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/load/DbFcfsServiceLoadTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
@@ -38,6 +39,9 @@ class DbFcfsServiceLoadTest {
     @Autowired
     private FcfsEventWinningInfoRepository fcfsEventWinningInfoRepository;
 
+    @Autowired
+    private RedisTemplate<String, Boolean> booleanRedisTemplate;
+
     Long numberOfWinners = 100L;
     int numberOfThreads = 200; // 스레드 수
     int numberOfUsers = 1000; // 동시 참여 사용자 수
@@ -48,6 +52,7 @@ class DbFcfsServiceLoadTest {
         fcfsEventWinningInfoRepository.deleteAll();
         eventUserRepository.deleteAll();
         fcfsEventRepository.deleteAll();
+        booleanRedisTemplate.getConnectionFactory().getConnection().flushAll();
 
         // 이벤트 생성
         FcfsEvent fcfsEvent = FcfsEvent.of(LocalDateTime.now(), LocalDateTime.now().plusDays(1), numberOfWinners, "prizeInfo", null);


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #41

# 📝 작업 내용

> Redis 자료구조의 key가 잘못 설정되어 있는 오타를 모두 수정했고, DB 기반 구현방안에도 다른 구현방안처럼 종료 Flag을 통한 성능상 이점을 보장하기 위해 Boolean Flag를 사용할 수 있도록 했습니다. 궁극적으로 일관성 있게 정리된 코드를 통해 신뢰성 있는 테스트를 가능하게 하고자 했습니다.

## 참고 이미지 및 자료
[Team AwesomeOrange 선착순 이벤트 구현방안 및 성능 보고서](https://github.com/softeerbootcamp4th/Team6-AwesomeOrange-BE/wiki/%EC%84%A0%EC%B0%A9%EC%88%9C-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EA%B5%AC%ED%98%84%EB%B0%A9%EC%95%88-%EB%B0%8F-%EC%84%B1%EB%8A%A5-%EB%B3%B4%EA%B3%A0%EC%84%9C)

# 💬 리뷰 요구사항

> 현재 선착순 이벤트의 핵심 메서드인 participate() 내부엔 여러 예외처리가 존재합니다. (이벤트 종료 여부, 이벤트 참여 여부, 잘못된 이벤트 참여 시간인지 검사, 이벤트 인원 마감 여부 등) 이 중 어떤 것은 false를 반환하지만 어떤 것은 Exception을 발생시키고 있어, validation 과정을 별도로 분리하기에 여러 에로사항이 있습니다. 
> 일단 더 이상의 코드 내부 내용 수정이 없는 상태로 만들기 위한 작업을 마쳤고, 추후 정제된 형식의 유효성 검사 메서드를 분리하기 위한 기준을 함께 마련해보면 좋을 듯 합니다.
> 현재 코로나에 확진된 상태라, 오늘과 내일은 테스트 데이터 기록에 집중하겠습니다. 심려를 끼쳐 드려 죄송합니다.