### PR TITLE
[chore] 선착순 이벤트 부하 테스트 관련 일부 수정 (#44)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -30,8 +30,9 @@ public class DbFcfsService implements FcfsService{
     @Override
     @Transactional
     public boolean participate(Long eventSequence, String userId){
+        String key = eventSequence.toString();
         // 이벤트 종료 여부 확인
-        if (isEventEnded(eventSequence)) {
+        if (isEventEnded(key)) {
             return false;
         }
 
@@ -54,7 +55,7 @@ public class DbFcfsService implements FcfsService{
         // 인원 수 초과 시 종료 flag 설정
         if(fcfsEvent.getInfos().size() >= fcfsEvent.getParticipantCount()){
             log.info("Event Finished: {},", fcfsEvent.getInfos().size());
-            endEvent(eventSequence);
+            endEvent(key);
             return false;
         }
 
@@ -67,11 +68,11 @@ public class DbFcfsService implements FcfsService{
         return fcfsEventWinningInfoRepository.existsByEventUserIdAndFcfsEventId(userId, eventSequence);
     }
 
-    private boolean isEventEnded(Long eventSequence){
-        return Boolean.TRUE.equals((booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(eventSequence.toString()))));
+    private boolean isEventEnded(String key){
+        return Boolean.TRUE.equals((booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(key))));
     }
 
-    private void endEvent(Long eventSequence){
-        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), true);
+    private void endEvent(String key){
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(key), true);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -53,11 +53,13 @@ public class DbFcfsService implements FcfsService{
 
         // 인원 수 초과 시 종료 flag 설정
         if(fcfsEvent.getInfos().size() >= fcfsEvent.getParticipantCount()){
+            log.info("Event Finished: {},", fcfsEvent.getInfos().size());
             endEvent(eventSequence);
             return false;
         }
 
         fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser));
+        log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
         return true;
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
@@ -4,11 +4,9 @@ import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
 import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FcfsAnswerService {
@@ -20,6 +18,6 @@ public class FcfsAnswerService {
         if (correctAnswer == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
-        return correctAnswer.equals(answer);
+        return correctAnswer.trim().equals(answer.trim()); // 정답 비교 시 공백을 제거
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -116,14 +116,15 @@ public class FcfsManageService {
     }
 
     private void prepareEventInfo(FcfsEvent event) {
-        numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(event.getId().toString()), event.getParticipantCount().intValue());
-        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(event.getId().toString()), false);
-        stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(event.getId().toString()), event.getStartTime().toString());
+        String key = event.getId().toString();
+        numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(key), event.getParticipantCount().intValue());
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(key), false);
+        stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(key), event.getStartTime().toString());
 
         // FIXME: 선착순 정답 생성 과정을 별도로 관리하는 것이 좋을 듯
         // 현재 정책 상 1~4 중 하나의 숫자를 선정하여 현재 선착순 이벤트의 정답에 저장
         int answer = new Random().nextInt(4) + 1;
-        stringRedisTemplate.opsForValue().set(FcfsUtil.answerFormatting(event.getId().toString()), String.valueOf(answer));
+        stringRedisTemplate.opsForValue().set(FcfsUtil.answerFormatting(key), String.valueOf(answer));
     }
 
     public void deleteEventInfo(String eventId) {

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -26,19 +26,20 @@ public class RedisLockFcfsService implements FcfsService {
 
     @Override
     public boolean participate(Long eventSequence, String userId) {
+        String key = eventSequence.toString();
         // 이벤트 종료 여부 확인
-        if (isEventEnded(eventSequence)) {
-            stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
+        if (isEventEnded(key)) {
+            stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);
             return false;
         }
 
         // 이미 이 이벤트에 참여했는지 확인
-        if(isParticipated(eventSequence, userId)) {
+        if(isParticipated(key, userId)) {
             throw new FcfsEventException(ErrorCode.ALREADY_PARTICIPATED);
         }
 
         // 잘못된 이벤트 참여 시간
-        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(key));
         if(startTime == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
@@ -55,16 +56,16 @@ public class RedisLockFcfsService implements FcfsService {
                 return false;
             }
 
-            int quantity = availableCoupons(FcfsUtil.keyFormatting(eventSequence.toString()));
+            int quantity = availableCoupons(FcfsUtil.keyFormatting(key));
             if (quantity <= 0) {
-                log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(eventSequence.toString())));
-                endEvent(eventSequence);  // 이벤트 종료 플래그 설정
+                log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(key)));
+                endEvent(key);  // 이벤트 종료 플래그 설정
                 return false;
             }
 
-            numberRedisTemplate.opsForValue().decrement(FcfsUtil.keyFormatting(eventSequence.toString()));
-            stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(eventSequence.toString()), userId, System.currentTimeMillis());
-            stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
+            numberRedisTemplate.opsForValue().decrement(FcfsUtil.keyFormatting(key));
+            stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(key), userId, System.currentTimeMillis());
+            stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);
             log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
             return true;
         } catch (InterruptedException e) {
@@ -77,8 +78,8 @@ public class RedisLockFcfsService implements FcfsService {
         }
     }
 
-    private boolean isParticipated(Long eventSequence, String userId){
-        return Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(FcfsUtil.participantFormatting(eventSequence.toString()), userId));
+    private boolean isParticipated(String key, String userId){
+        return Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(FcfsUtil.participantFormatting(key), userId));
     }
 
     private Integer availableCoupons(String key) {
@@ -89,11 +90,11 @@ public class RedisLockFcfsService implements FcfsService {
         return count;
     }
 
-    private boolean isEventEnded(Long eventSequence) {
-        return Boolean.TRUE.equals(booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(eventSequence.toString())));
+    private boolean isEventEnded(String key) {
+        return Boolean.TRUE.equals(booleanRedisTemplate.opsForValue().get(FcfsUtil.endFlagFormatting(key)));
     }
 
-    private void endEvent(Long eventSequence) {
-        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), true);
+    private void endEvent(String key) {
+        booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(key), true);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -57,6 +57,7 @@ public class RedisLockFcfsService implements FcfsService {
 
             int quantity = availableCoupons(FcfsUtil.keyFormatting(eventSequence.toString()));
             if (quantity <= 0) {
+                log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(eventSequence.toString())));
                 endEvent(eventSequence);  // 이벤트 종료 플래그 설정
                 return false;
             }
@@ -64,6 +65,7 @@ public class RedisLockFcfsService implements FcfsService {
             numberRedisTemplate.opsForValue().decrement(FcfsUtil.keyFormatting(eventSequence.toString()));
             stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(eventSequence.toString()), userId, System.currentTimeMillis());
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
+            log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
             return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -18,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-@Primary
 public class RedisLockFcfsService implements FcfsService {
 
     private final StringRedisTemplate stringRedisTemplate;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -5,6 +5,7 @@ import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
 import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
@@ -15,6 +16,7 @@ import java.util.Collections;
 
 @Slf4j
 @RequiredArgsConstructor
+@Primary
 @Service
 public class RedisLuaFcfsService implements FcfsService {
 
@@ -62,6 +64,7 @@ public class RedisLuaFcfsService implements FcfsService {
         );
 
         if(result == null || result <= 0) {
+            log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(eventSequence.toString())));
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
             endEvent(eventSequence);
             return false;
@@ -69,7 +72,7 @@ public class RedisLuaFcfsService implements FcfsService {
 
         stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(eventSequence.toString()), userId, System.currentTimeMillis());
         stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
-        log.info("Event Sequence: {}, User ID: {}, Timestamp: {}", eventSequence, userId, timestamp);
+        log.info("Participating Success: {}, User ID: {}, Timestamp: {}", eventSequence, userId, timestamp);
         return true;
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
@@ -44,13 +44,14 @@ public class RedisSetFcfsService implements FcfsService {
 
         // 이벤트 인원 마감 여부 확인
         if (isEventFull(eventSequence)) {
+            log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(eventSequence.toString())));
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
             return false;
         }
 
         stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(eventSequence.toString()), userId, System.currentTimeMillis());
         stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(eventSequence.toString()), userId);
-        log.info("{} 선착순 이벤트 참여 성공", userId);
+        log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
         return true;
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -7,28 +7,28 @@ import lombok.NoArgsConstructor;
 public class FcfsUtil {
 
     // 선착순 이벤트 tag
-    public static String keyFormatting(String fcfsId) {
-        return fcfsId + ":fcfs";
+    public static String keyFormatting(String key) {
+        return key + ":fcfs";
     }
 
     // 선착순 이벤트 시작 시각 tag
-    public static String startTimeFormatting(String fcfsId) {
-        return fcfsId + "_start";
+    public static String startTimeFormatting(String key) {
+        return key + "_start";
     }
 
     // 선착순 이벤트 마감 여부 tag
-    public static String endFlagFormatting(String fcfsId) {
-        return fcfsId + "_end";
+    public static String endFlagFormatting(String key) {
+        return key + "_end";
     }
 
     // 선착순 이벤트 당첨자 tag
-    public static String winnerFormatting(String fcfsId) {
-        return fcfsId + "_winner";
+    public static String winnerFormatting(String key) {
+        return key + "_winner";
     }
 
     // 선착순 이벤트 참여자 tag
-    public static String participantFormatting(String fcfsId) {
-        return fcfsId + "_participant";
+    public static String participantFormatting(String key) {
+        return key + "_participant";
     }
 
     // 선착순 이벤트 정답 tag


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #44

# 📝 작업 내용
> 유효한 JWT 토큰을 더미 유저 기반으로 생성하고 이를 활용해 실제로 사용될 선착순 API의 성능을 검증하여 테스트의 신뢰성을 높이고자 했습니다. 

> 또한, 정답을 맞히는 과정에서 일부 문자열 내부 공백으로 인해 오동작하는 문제가 있어 이를 trim()을 붙여 문제를 해결했습니다.

> 한편, 모든 구현체마다 Long -> toString()의 중복이 많아 이를 key 변수에 통합하고 관리하도록 수정했고, 로그 내용도 통일했습니다.

> 마지막으로, JMeter에서 부하 테스트를 할 때는 반드시 CLI로 실행할 것을 강력히 권장하고 있어, 존재해 기존의 GUI 방식에서 CLI를 통해 실행하는 것으로 선회했습니다. 이 과정에서 GUI와 달리 에러 비율이 나타나는 것을 확인할 수 있었습니다. 개인적으로 CLI의 스레드 투입 수가 GUI보다 빠른 것이 아닐까 추측 중입니다.

> 총 10회의 테스트를 자동으로 1분 간격으로 수행하고 아래와 같은 형태로 로그를 자동 출력하여 평균치 계산을 수월하게 만드는 test.sh를 작성하여 테스트를 실행하고 기록하는 동안 다른 작업에 집중할 수 있게 하여 생산성을 높이고자 했습니다. 

<img width="654" alt="image" src="https://github.com/user-attachments/assets/6a7dcb5f-f279-46b9-b203-8126e8b72726">

- [x] 내부 공백으로 인해 judgeAnswer가 의도대로 동작하지 않는 버그 수정
- [x] FcfsService 구현체마다 남용되는 toString() 제거
- [x] 일관된 로그 작성
- [x] Default ServiceImpl을 RedisLuaService로 지정
- [x] 더미 유저 정보 입력하여 JWT 토큰 추출하고 csv로 저장하는 Python 모듈 작성
- [x] 부하 테스트 10회를 자동으로 수행하고 로그를 기록하는 쉘 스크립트 test.sh 작성
- [x] Apache Jmeter로 실제 사용될 API 엔드포인트로 부하 테스트 실행하고 기록

## 참고 이미지 및 자료
[Team AwesomeOrange 선착순 이벤트 구현방안 및 성능 보고서](https://github.com/softeerbootcamp4th/Team6-AwesomeOrange-BE/wiki/%EC%84%A0%EC%B0%A9%EC%88%9C-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EA%B5%AC%ED%98%84%EB%B0%A9%EC%95%88-%EB%B0%8F-%EC%84%B1%EB%8A%A5-%EB%B3%B4%EA%B3%A0%EC%84%9C)

# 💬 리뷰 요구사항