### PR TITLE
[fix] API Spec 수정 (#47)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -31,18 +31,18 @@ public class CommentController {
     private final ApiService apiService;
 
     @Tag(name = "Comment")
-    @GetMapping
+    @GetMapping("/{eventFrameId}")
     @Operation(summary = "기대평 조회", description = "주기적으로 추출되는 긍정 기대평 목록을 조회한다.", responses = {
             @ApiResponse(responseCode = "200", description = "기대평 조회 성공",
                     content = @Content(schema = @Schema(implementation = ResponseCommentsDto.class)))
     })
-    public ResponseEntity<ResponseCommentsDto> getComments() {
-        return ResponseEntity.ok(commentService.getComments());
+    public ResponseEntity<ResponseCommentsDto> getComments(@PathVariable Long eventFrameId) {
+        return ResponseEntity.ok(commentService.getComments(eventFrameId));
     }
 
     @Auth(AuthRole.event_user)
     @Tag(name = "Comment")
-    @PostMapping
+    @PostMapping("/{eventFrameId}")
     @Operation(summary = "기대평 등록", description = "유저가 신규 기대평을 등록한다.", responses = {
             @ApiResponse(responseCode = "200", description = "기대평 등록 성공",
                     content = @Content(schema = @Schema(implementation = Boolean.class))),
@@ -53,9 +53,9 @@ public class CommentController {
             @ApiResponse(responseCode = "409", description = "하루에 여러 번의 기대평을 작성하려 할 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> createComment(@EventUserAnnotation EventUserInfo userInfo, @RequestBody @Valid CreateCommentDto dto) {
+    public ResponseEntity<Boolean> createComment(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
         boolean isPositive = apiService.analyzeComment(dto.getContent());
-        return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), dto, isPositive));
+        return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto, isPositive));
     }
 
     @Auth(AuthRole.event_user)

--- a/src/main/java/hyundai/softeer/orange/comment/dto/CreateCommentDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/CreateCommentDto.java
@@ -1,25 +1,16 @@
 package hyundai.softeer.orange.comment.dto;
 
 import hyundai.softeer.orange.common.util.MessageUtil;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class CreateCommentDto {
-
-    @NotNull(message = MessageUtil.BAD_INPUT)
-    private Long eventFrameId;
 
     @Size(min = 1, max = 100, message = MessageUtil.OUT_OF_SIZE)
     private String content;
-
-    public CreateCommentDto(Long eventFrameId, String content) {
-        this.eventFrameId = eventFrameId;
-        this.content = content;
-    }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     // DB 상에서 무작위로 추출된 n개의 긍정 기대평 목록을 조회
-    @Query(value = "SELECT * FROM comment WHERE is_positive = true ORDER BY RAND() LIMIT :n", nativeQuery = true)
-    List<Comment> findRandomPositiveComments(@Param("n") int n);
+    @Query(value = "SELECT * FROM comment WHERE event_frame_id = :eventFrameId AND is_positive = true ORDER BY RAND() LIMIT :n", nativeQuery = true)
+    List<Comment> findRandomPositiveComments(Long eventFrameId, @Param("n") int n);
 
     // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인
     @Query(value = "SELECT COUNT(*) FROM comment WHERE event_user_id = :eventUserId AND DATE(createdAt) = CURDATE()", nativeQuery = true)

--- a/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
@@ -2,19 +2,24 @@ package hyundai.softeer.orange.comment.scheduler;
 
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.util.ConstantUtil;
+import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Component
 public class CommentScheduler {
 
     private final CommentService commentService;
+    private final EventFrameRepository eventFrameRepository;
 
     // 스케줄러에 의해 일정 시간마다 캐싱된 긍정 기대평 목록을 초기화한다.
     @Scheduled(fixedRate = ConstantUtil.SCHEDULED_TIME) // 2시간마다 실행
     private void clearCache() {
-        commentService.getComments();
+        List<Long> eventFrameIds = eventFrameRepository.findAllIds();
+        eventFrameIds.forEach(commentService::getComments);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -31,9 +31,9 @@ public class CommentService {
 
     // 주기적으로 무작위 추출되는 긍정 기대평 목록을 조회한다.
     @Transactional(readOnly = true)
-    @Cacheable(value = "comments", key = ConstantUtil.COMMENTS_KEY)
-    public ResponseCommentsDto getComments() {
-        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(ConstantUtil.COMMENTS_SIZE)
+    @Cacheable(value = "comments", key = ConstantUtil.COMMENTS_KEY + " + #eventFrameId")
+    public ResponseCommentsDto getComments(Long eventFrameId) {
+        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(eventFrameId, ConstantUtil.COMMENTS_SIZE)
                 .stream()
                 .map(ResponseCommentDto::from)
                 .toList();
@@ -42,10 +42,10 @@ public class CommentService {
 
     // 신규 기대평을 등록한다.
     @Transactional
-    public Boolean createComment(String userId, CreateCommentDto dto, Boolean isPositive) {
+    public Boolean createComment(String userId, Long eventFrameId, CreateCommentDto dto, Boolean isPositive) {
         EventUser eventUser = eventUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new CommentException(ErrorCode.EVENT_USER_NOT_FOUND));
-        EventFrame eventFrame = eventFrameRepository.findById(dto.getEventFrameId())
+        EventFrame eventFrame = eventFrameRepository.findById(eventFrameId)
                 .orElseThrow(() -> new CommentException(ErrorCode.EVENT_FRAME_NOT_FOUND));
 
         // 하루에 여러 번의 기대평을 작성하려 할 때 예외처리

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
@@ -2,11 +2,16 @@ package hyundai.softeer.orange.event.common.repository;
 
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface EventFrameRepository extends JpaRepository<EventFrame, Long> {
     Optional<EventFrame> findByName(String name);
+
+    @Query("SELECT ef.id FROM EventFrame ef")
+    List<Long> findAllIds();
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.event.fcfs.controller;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.event.fcfs.dto.RequestAnswerDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsInfoDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsResultDto;
 import hyundai.softeer.orange.event.fcfs.service.FcfsAnswerService;
@@ -31,15 +32,15 @@ public class FcfsController {
 
     @Auth(AuthRole.event_user)
     @Tag(name = "fcfs")
-    @PostMapping
+    @PostMapping("/{eventSequence}")
     @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패",
                     content = @Content(schema = @Schema(implementation = ResponseFcfsResultDto.class))),
             @ApiResponse(responseCode = "400", description = "선착순 이벤트 시간이 아니거나, 요청 형식이 잘못된 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseFcfsResultDto> participate(@EventUserAnnotation EventUserInfo userInfo, @RequestParam Long eventSequence, @RequestParam String eventAnswer) {
-        boolean answerResult = fcfsAnswerService.judgeAnswer(eventSequence, eventAnswer);
+    public ResponseEntity<ResponseFcfsResultDto> participate(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence, @RequestBody RequestAnswerDto dto) {
+        boolean answerResult = fcfsAnswerService.judgeAnswer(eventSequence, dto.getAnswer());
         boolean isWin = answerResult && fcfsService.participate(eventSequence, userInfo.getUserId());
         return ResponseEntity.ok(new ResponseFcfsResultDto(answerResult, isWin));
     }
@@ -58,14 +59,14 @@ public class FcfsController {
 
     @Auth(AuthRole.event_user)
     @Tag(name = "fcfs")
-    @GetMapping("/participated")
+    @GetMapping("/{eventSequence}/participated")
     @Operation(summary = "선착순 이벤트 참여 여부 조회", description = "정답을 맞혀서 선착순 이벤트에 참여했는지 여부를 조회한다. (당첨은 별도)", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트의 정답을 맞혀서 참여했는지에 대한 결과",
                     content = @Content(schema = @Schema(implementation = ResponseFcfsResultDto.class))),
             @ApiResponse(responseCode = "404", description = "선착순 이벤트를 찾을 수 없는 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> isParticipated(@EventUserAnnotation EventUserInfo userInfo, @RequestParam Long eventSequence) {
+    public ResponseEntity<Boolean> isParticipated(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence) {
         return ResponseEntity.ok(fcfsManageService.isParticipated(eventSequence, userInfo.getUserId()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/RequestAnswerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/RequestAnswerDto.java
@@ -1,0 +1,12 @@
+package hyundai.softeer.orange.event.fcfs.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestAnswerDto {
+    private String answer;
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #47

# 📝 작업 내용

> FE에서 제안한 대로 API 스펙을 일부 조정했습니다.
- [x] 기대평 조회 시 이벤트별로 조회가 가능하도록 수정
- [x] 선착순 이벤트(fcfs) 관련 API 매개변수를 RequestParam에서 RequestBody, PathVariable 등으로 수정
- [x] 기존 테스트코드에 변동사항 반영

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
> 현재 h2를 활용한 테스트 코드가 제 노트북에서는 모두 실패하고 있는 버그가 있습니다. 어떤 장치에서도 안정적으로 테스트 환경을 세팅할 수 있는 테스트 컨테이너를 만들어 CI/CD 과정에 삽입하는 것이 안전해 보입니다. 