### PR TITLE
[chore] FE와 주고받는 EventFrame 식별자 PK가 아닌 별도 필드로 수정 (#52) 

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/service/AdminAuthService.java
+++ b/src/main/java/hyundai/softeer/orange/admin/service/AdminAuthService.java
@@ -8,6 +8,8 @@ import hyundai.softeer.orange.core.auth.AuthRole;
 import hyundai.softeer.orange.core.jwt.JWTManager;
 import hyundai.softeer.orange.core.security.PasswordManager;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -16,6 +18,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class AdminAuthService {
+    private static final Logger log = LoggerFactory.getLogger(AdminAuthService.class);
     private final AdminRepository adminRepository;
     private final PasswordManager pwManager;
     private final JWTManager jwtManager;
@@ -56,7 +59,7 @@ public class AdminAuthService {
                 .password(encryptedPassword)
                 .nickName(nickname)
                 .build();
-
+        log.info("admin signed up: {}", admin.getUserName());
         adminRepository.save(admin);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -36,7 +36,7 @@ public class CommentController {
             @ApiResponse(responseCode = "200", description = "기대평 조회 성공",
                     content = @Content(schema = @Schema(implementation = ResponseCommentsDto.class)))
     })
-    public ResponseEntity<ResponseCommentsDto> getComments(@PathVariable Long eventFrameId) {
+    public ResponseEntity<ResponseCommentsDto> getComments(@PathVariable String eventFrameId) {
         return ResponseEntity.ok(commentService.getComments(eventFrameId));
     }
 
@@ -53,7 +53,7 @@ public class CommentController {
             @ApiResponse(responseCode = "409", description = "하루에 여러 번의 기대평을 작성하려 할 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> createComment(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
+    public ResponseEntity<Boolean> createComment(@EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
         boolean isPositive = apiService.analyzeComment(dto.getContent());
         return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto, isPositive));
     }

--- a/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
@@ -19,7 +19,7 @@ public class CommentScheduler {
     // 스케줄러에 의해 일정 시간마다 캐싱된 긍정 기대평 목록을 초기화한다.
     @Scheduled(fixedRate = ConstantUtil.SCHEDULED_TIME) // 2시간마다 실행
     private void clearCache() {
-        List<Long> eventFrameIds = eventFrameRepository.findAllIds();
-        eventFrameIds.forEach(commentService::getComments);
+        List<String> frameIds = eventFrameRepository.findAllFrameIds();
+        frameIds.forEach(commentService::getComments);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/service/ApiService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/ApiService.java
@@ -8,6 +8,8 @@ import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.config.NaverApiConfig;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class ApiService {
 
+    private static final Logger log = LoggerFactory.getLogger(ApiService.class);
     private final NaverApiConfig naverApiConfig;
 
     public boolean analyzeComment(String content) {
@@ -48,6 +51,7 @@ public class ApiService {
         } catch (JsonProcessingException e) {
             throw new CommentException(ErrorCode.INVALID_JSON);
         }
+        log.info("comment <{}> sentiment analysis result: {}", content, isPositive);
         return isPositive;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -32,8 +32,10 @@ public class CommentService {
     // 주기적으로 무작위 추출되는 긍정 기대평 목록을 조회한다.
     @Transactional(readOnly = true)
     @Cacheable(value = "comments", key = ConstantUtil.COMMENTS_KEY + " + #eventFrameId")
-    public ResponseCommentsDto getComments(Long eventFrameId) {
-        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(eventFrameId, ConstantUtil.COMMENTS_SIZE)
+    public ResponseCommentsDto getComments(String eventFrameId) {
+        EventFrame frame = eventFrameRepository.findByFrameId(eventFrameId)
+                .orElseThrow(() -> new CommentException(ErrorCode.EVENT_FRAME_NOT_FOUND));
+        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(frame.getId(), ConstantUtil.COMMENTS_SIZE)
                 .stream()
                 .map(ResponseCommentDto::from)
                 .toList();
@@ -42,10 +44,10 @@ public class CommentService {
 
     // 신규 기대평을 등록한다.
     @Transactional
-    public Boolean createComment(String userId, Long eventFrameId, CreateCommentDto dto, Boolean isPositive) {
+    public Boolean createComment(String userId, String eventFrameId, CreateCommentDto dto, Boolean isPositive) {
         EventUser eventUser = eventUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new CommentException(ErrorCode.EVENT_USER_NOT_FOUND));
-        EventFrame eventFrame = eventFrameRepository.findById(eventFrameId)
+        EventFrame eventFrame = eventFrameRepository.findByFrameId(eventFrameId)
                 .orElseThrow(() -> new CommentException(ErrorCode.EVENT_FRAME_NOT_FOUND));
 
         // 하루에 여러 번의 기대평을 작성하려 할 때 예외처리

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
@@ -11,7 +11,6 @@ import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.EventFrameCreateRequest;
 import hyundai.softeer.orange.event.dto.EventSearchHintDto;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -115,7 +114,7 @@ public class AdminEventController {
             @ApiResponse(responseCode = "4xx", description = "이벤트 프레임 생성 실패")
     })
     public ResponseEntity<Void> createEventFrame(@Valid @RequestBody EventFrameCreateRequest req) {
-        eventService.createEventFrame(req.getName());
+        eventService.createEventFrame(req.getFrameId(), req.getName());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventFrame.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventFrame.java
@@ -19,6 +19,11 @@ public class EventFrame {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // 클라이언트가 PathVariable로 넘겨줄 값 (ex: the-new-ioniq5)
+    @Column(unique = true, nullable = false)
+    private String frameId;
+
+    // 어드민에서 노출될 이름 (ex: 2024 하반기 신차 출시 이벤트)
     @Column(unique = true, nullable = false)
     private String name;
 
@@ -31,8 +36,9 @@ public class EventFrame {
     @OneToMany(mappedBy="eventFrame")
     private List<Comment> commentList = new ArrayList<>();
 
-    public static EventFrame of(String name) {
+    public static EventFrame of(String frame, String name) {
         EventFrame eventFrame = new EventFrame();
+        eventFrame.frameId = frame;
         eventFrame.name = name;
         return eventFrame;
     }

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 public interface EventFrameRepository extends JpaRepository<EventFrame, Long> {
     Optional<EventFrame> findByName(String name);
 
-    @Query("SELECT ef.id FROM EventFrame ef")
-    List<Long> findAllIds();
+    @Query("SELECT ef.frameId FROM EventFrame ef")
+    List<String> findAllFrameIds();
+
+    Optional<EventFrame> findByFrameId(String frameId);
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -230,8 +230,8 @@ public class EventService {
      * @param name 이벤트 프레임의 이름
      */
     @Transactional
-    public void createEventFrame(String name) {
-        EventFrame eventFrame = EventFrame.of(name);
+    public void createEventFrame(String frameId, String name) {
+        EventFrame eventFrame = EventFrame.of(frameId, name);
         efRepository.save(eventFrame);
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -12,6 +12,8 @@ import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
 import hyundai.softeer.orange.event.draw.component.picker.WinnerPicker;
 import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Service
 public class DrawEventService {
+    private static final Logger log = LoggerFactory.getLogger(DrawEventService.class);
     private final DrawEventRepository deRepository;
     private final DrawEventWinningInfoRepository deWinningInfoRepository;
     private final WinnerPicker picker;
@@ -91,6 +94,7 @@ public class DrawEventService {
             remain--;
         }
 
+        log.info("Draw Event: {}, Winners: {}", drawEventRawId, insertTargets.size());
         deWinningInfoRepository.insertMany(insertTargets);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventFrameCreateRequest.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventFrameCreateRequest.java
@@ -6,5 +6,7 @@ import lombok.Getter;
 @Getter
 public class EventFrameCreateRequest {
     @NotBlank
+    private String frameId;
+    @NotBlank
     private String name;
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -4,7 +4,8 @@ import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.event.fcfs.exception.FcfsEventException;
 import hyundai.softeer.orange.event.fcfs.util.FcfsUtil;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -14,12 +15,12 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.Collections;
 
-@Slf4j
 @RequiredArgsConstructor
 @Primary
 @Service
 public class RedisLuaFcfsService implements FcfsService {
 
+    private static final Logger log = LoggerFactory.getLogger(RedisLuaFcfsService.class);
     private final StringRedisTemplate stringRedisTemplate;
     private final RedisTemplate<String, Integer> numberRedisTemplate;
     private final RedisTemplate<String, Boolean> booleanRedisTemplate;

--- a/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/service/UrlService.java
@@ -8,6 +8,8 @@ import hyundai.softeer.orange.event.url.exception.UrlException;
 import hyundai.softeer.orange.event.url.repository.UrlRepository;
 import hyundai.softeer.orange.event.url.util.UrlTypeValidation;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +19,7 @@ import java.util.Random;
 @Service
 public class UrlService {
 
+    private static final Logger log = LoggerFactory.getLogger(UrlService.class);
     private final UrlRepository urlRepository;
 
     @Transactional
@@ -33,6 +36,7 @@ public class UrlService {
 
         Url url = Url.of(originalUrl, shortUrl);
         urlRepository.save(url);
+        log.info("shortUrl generated: {}", shortUrl);
         return new ResponseUrlDto(shortUrl);
     }
 
@@ -40,6 +44,7 @@ public class UrlService {
     public String getOriginalUrl(String shortUrl) {
         Url url = urlRepository.findByShortUrl(shortUrl)
                 .orElseThrow(() -> new UrlException(ErrorCode.SHORT_URL_NOT_FOUND));
+        log.info("shortUrl {}'s originalUrl fetched: {}", shortUrl, url.getOriginalUrl());
         return url.getOriginalUrl();
     }
 

--- a/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
@@ -64,7 +64,7 @@ public class EventUserController {
             @ApiResponse(responseCode = "401", description = "인증번호가 일치하지 않을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    public ResponseEntity<TokenDto> checkAuthCode(@PathVariable Long eventFrameId,  @RequestBody @Valid RequestAuthCodeDto dto) {
+    public ResponseEntity<TokenDto> checkAuthCode(@PathVariable String eventFrameId,  @RequestBody @Valid RequestAuthCodeDto dto) {
         return ResponseEntity.ok(eventUserService.checkAuthCode(dto, eventFrameId));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/CoolSmsService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/CoolSmsService.java
@@ -49,10 +49,10 @@ public class CoolSmsService implements SmsService {
         message.setText("[소프티어 오렌지] 인증번호는 (" + authCode + ")입니다.");
 
         SingleMessageSentResponse response = defaultMessageService.sendOne(new SingleMessageSendingRequest(message));
-        log.info("{}에게 SMS 전송 완료: {}", dto.getPhoneNumber(), response);
 
         // 5분 동안 인증번호 유효
         stringRedisTemplate.opsForValue().set(dto.getPhoneNumber(), authCode, ConstantUtil.AUTH_CODE_EXPIRE_TIME, TimeUnit.MINUTES);
+        log.info("successfully send SMS to {}, response: {}", dto.getPhoneNumber(), response);
     }
 
     // 6자리 난수 인증번호 생성

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
@@ -49,7 +49,7 @@ public class EventUserService {
      * 4. 전화번호로 발송된 인증번호가 존재하지 않는다면 400 예외
      */
     @Transactional
-    public TokenDto checkAuthCode(RequestAuthCodeDto dto, Long eventFrameId) {
+    public TokenDto checkAuthCode(RequestAuthCodeDto dto, String eventFrameId) {
         // Redis에서 인증번호 조회
         String authCode = stringRedisTemplate.opsForValue().get(dto.getPhoneNumber());
 
@@ -67,7 +67,7 @@ public class EventUserService {
         stringRedisTemplate.delete(dto.getPhoneNumber());
 
         // DB에 유저 데이터 저장
-        EventFrame eventFrame = eventFrameRepository.findById(eventFrameId)
+        EventFrame eventFrame = eventFrameRepository.findByFrameId(eventFrameId)
                 .orElseThrow(() -> new EventUserException(ErrorCode.EVENT_FRAME_NOT_FOUND));
         String userId = UUID.randomUUID().toString().substring(0, ConstantUtil.USER_ID_LENGTH);
         EventUser eventUser = EventUser.of(dto.getName(), dto.getPhoneNumber(), eventFrame, userId);

--- a/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
@@ -58,7 +58,7 @@ class CommentControllerTest {
     private AuthInterceptor authInterceptor;
 
     ObjectMapper mapper = new ObjectMapper();
-    Long eventFrameId = 1L;
+    String eventFrameId = "the-new-ioniq5";
     CreateCommentDto createCommentDto = new CreateCommentDto("hello");
     String requestBody = "";
 
@@ -110,7 +110,7 @@ class CommentControllerTest {
     void createComment200Test() throws Exception {
         // given
         when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyLong(), any(CreateCommentDto.class), anyBoolean())).thenReturn(true);
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean())).thenReturn(true);
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders
@@ -127,7 +127,7 @@ class CommentControllerTest {
     void createComment400Test() throws Exception {
         // given
         when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyLong(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
                 .thenThrow(new CommentException(ErrorCode.INVALID_COMMENT));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_COMMENT));
 
@@ -167,7 +167,7 @@ class CommentControllerTest {
     void createComment404Test() throws Exception {
         // given
         when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyLong(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
                 .thenThrow(new CommentException(ErrorCode.EVENT_USER_NOT_FOUND));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.EVENT_USER_NOT_FOUND));
 
@@ -186,7 +186,7 @@ class CommentControllerTest {
     void createComment409Test() throws Exception {
         // given
         when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyLong(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
                 .thenThrow(new CommentException(ErrorCode.COMMENT_ALREADY_EXISTS));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.COMMENT_ALREADY_EXISTS));
 

--- a/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.TestPropertySource;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 @DataJpaTest
 @TestPropertySource(locations = "classpath:application-test.yml")
 class EventSpecificationTest {
@@ -26,7 +27,7 @@ class EventSpecificationTest {
     @DisplayName("search가 없으면 predicate는 항상 참")
     @Test
     void searchWithoutSearchClause() {
-        EventFrame ef = EventFrame.of("test");
+        EventFrame ef = EventFrame.of("the-new-ioniq5", "test");
         efRepository.save(ef);
         EventMetadata em1 = EventMetadata.builder()
                 .eventId("HD240805_001")
@@ -60,7 +61,7 @@ class EventSpecificationTest {
     @Test
     void searchWithSearchClause() {
         String search = "event";
-        EventFrame ef = EventFrame.of("test");
+        EventFrame ef = EventFrame.of("the-new-ioniq5","test");
         efRepository.save(ef);
         // event 포함 ( name )
         EventMetadata em1 = EventMetadata.builder()

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 
 @DataJpaTest
 @TestPropertySource(locations = "classpath:application-test.yml")
-public class EventServiceSearchEventsTest {
+class EventServiceSearchEventsTest {
     @Autowired
     private EventMetadataRepository emRepo;
     @Autowired
@@ -37,7 +37,7 @@ public class EventServiceSearchEventsTest {
         mapperMatcher = mock(EventFieldMapperMatcher.class);
         keyGenerator = mock(EventKeyGenerator.class);
         eventService = new EventService(efRepo, emRepo, mapperMatcher, keyGenerator, null, null);
-        EventFrame ef = EventFrame.of("test");
+        EventFrame ef = EventFrame.of("the-new-ioniq5","test");
         efRepo.save(ef);
         EventMetadata em1 = EventMetadata.builder()
                 .eventId("HD240805_001")

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
@@ -7,8 +7,6 @@ import hyundai.softeer.orange.event.common.enums.EventType;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
-import hyundai.softeer.orange.event.draw.entity.DrawEvent;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +22,7 @@ import static org.mockito.Mockito.mock;
 
 @DataJpaTest
 @TestPropertySource(locations = "classpath:application-test.yml")
-public class EventServiceSearchHintsTest {
+class EventServiceSearchHintsTest {
     @Autowired
     private EventMetadataRepository emRepo;
     @Autowired
@@ -40,7 +38,7 @@ public class EventServiceSearchHintsTest {
         keyGenerator = mock(EventKeyGenerator.class);
         eventService = new EventService(efRepo, emRepo, mapperMatcher, keyGenerator, null, null);
         // 이벤트 프레임 생성
-        EventFrame ef = EventFrame.of("test");
+        EventFrame ef = EventFrame.of("the-new-ioniq5","test");
         efRepo.save(ef);
 
         // 이벤트 메타데이터 생성

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -61,7 +60,7 @@ class EventServiceTest {
         EventDto eventDto = mock(EventDto.class);
         when(eventDto.getTag()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
-        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("test")));
+        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
 
         assertThatThrownBy(() -> {
             eventService.createEvent(eventDto);
@@ -75,7 +74,7 @@ class EventServiceTest {
         EventDto eventDto = mock(EventDto.class);
         when(eventDto.getTag()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
-        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("test")));
+        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
         when(mapperMatcher.getMapper(any(EventType.class))).thenReturn(mock(FcfsEventFieldMapper.class));
 
         eventService.createEvent(eventDto);

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
@@ -65,7 +65,7 @@ class FcfsManageServiceTest {
         eventUserRepository.deleteAll();
         eventFrameRepository.deleteAll();
 
-        EventFrame eventFrame = EventFrame.of("FcfsManageServiceTest");
+        EventFrame eventFrame = EventFrame.of("the-new-ioniq5","FcfsManageServiceTest");
         FcfsEvent fcfsEvent = FcfsEvent.builder()
                 .startTime(LocalDateTime.now().plusSeconds(10))
                 .participantCount(10L)

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
@@ -28,8 +28,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -56,7 +55,7 @@ class EventUserControllerTest {
     ObjectMapper mapper = new ObjectMapper();
     RequestUserDto requestUserDto = new RequestUserDto("hyundai", "01000000000");
     TokenDto tokenDto = new TokenDto("token");
-    Long eventFrameId = 1L;
+    String eventFrameId = "the-new-ioniq5";
 
     @DisplayName("login: 로그인 API를 호출한다.")
     @ParameterizedTest(name = "name: {0}, phoneNumber: {1}")
@@ -135,7 +134,7 @@ class EventUserControllerTest {
         RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456");
         String requestBody = mapper.writeValueAsString(requestAuthCodeDto);
         String responseBody = mapper.writeValueAsString(tokenDto);
-        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyLong())).thenReturn(tokenDto);
+        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyString())).thenReturn(tokenDto);
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth/" + eventFrameId)
@@ -172,7 +171,7 @@ class EventUserControllerTest {
         RequestAuthCodeDto requestAuthCodeDto = new RequestAuthCodeDto("name", "01000000000", "123456");
         String requestBody = mapper.writeValueAsString(requestAuthCodeDto);
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_AUTH_CODE));
-        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyLong())).thenThrow(new EventUserException(ErrorCode.INVALID_AUTH_CODE));
+        when(eventUserService.checkAuthCode(any(RequestAuthCodeDto.class), anyString())).thenThrow(new EventUserException(ErrorCode.INVALID_AUTH_CODE));
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/check-auth/" + eventFrameId)

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
@@ -54,6 +54,7 @@ class EventUserServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        given(eventFrameRepository.findByFrameId(eventFrameId)).willReturn(Optional.of(eventFrame));
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
     }
 
@@ -62,9 +63,9 @@ class EventUserServiceTest {
             .phoneNumber("01012345678")
             .build();
     TokenDto tokenDto = new TokenDto("token");
-    EventFrame eventFrame = EventFrame.of("eventFrame");
+    EventFrame eventFrame = EventFrame.of("the-new-ioniq5", "eventFrame");
     EventUser eventUser = EventUser.of("test", "01000000000", eventFrame, "uuid");
-    Long eventFrameId = 1L;
+    String eventFrameId = "the-new-ioniq5";
 
     @DisplayName("login: 유저가 로그인한다.")
     @Test

--- a/src/test/resources/sql/CommentRepositoryTest.sql
+++ b/src/test/resources/sql/CommentRepositoryTest.sql
@@ -1,5 +1,5 @@
-INSERT INTO event_frame(name) VALUES ('test1');
-INSERT INTO event_frame(name) VALUES ('test2');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id1', 'test1');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id2','test2');
 
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 1, 'HD_240808_001');
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (0, 2, 'HD_240808_002');

--- a/src/test/resources/sql/CustomDrawEventWinningInfoRepositoryImplTest.sql
+++ b/src/test/resources/sql/CustomDrawEventWinningInfoRepositoryImplTest.sql
@@ -1,4 +1,4 @@
-INSERT INTO event_frame(name) VALUES ('test');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id1', 'test');
 
 INSERT INTO event_metadata(event_type, event_frame_id, event_id)
 VALUES (1, 1, 'HD_240808_001');

--- a/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
+++ b/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
@@ -1,6 +1,6 @@
-INSERT INTO event_frame(name) VALUES ('test1');
-INSERT INTO event_frame(name) VALUES ('test2');
-INSERT INTO event_frame(name) VALUES ('test3');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id1', 'test1');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id2', 'test2');
+INSERT INTO event_frame(frame_id, name) VALUES ('frame_id3', 'test3');
 
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 1, 'HD_240808_001');
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 2, 'HD_240808_002');


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #52

# 📝 작업 내용

> FE와 주고받는 EventFrame의 식별자를 Long 형태의 PK가 아닌 의미있는 String(ex: "the-new-ioniq5")인 frameId를 주고받도록 수정하였습니다. 이를 통해 본래 식별자를 은닉하고 사용자 경험을 일부 개선할 수 있을 것입니다.
> 또한, Grafana Loki를 활용한 로그 수집을 대비하여 핵심 기능에 개략적으로로그를 추가하여 원활한 모니터링을 실현하는데 일부 기여하고자 합니다. 구체적인 로그 작성 규칙은 추후 여유가 있을 때 협의하면 될 것으로 보입니다.

- [x] EventFrame에 frameId 필드 추가
- [x] 관련된 비즈니스 로직 및 API 스펙 변경
- [x] 테스트 코드 반영
- [x] 일부 표현 수정 및 사용하지 않는 import 제거
- [x] 추후 Grafana 도입 대비 핵심 기능에 로깅 추가

![image](https://github.com/user-attachments/assets/9afea825-d05a-40da-93b2-d6e703c1187d)

> 특이사항으로, h2 기반의 통합 테스트 5개가 제 디바이스에서만 실패하고 있습니다. 확실한 원인을 찾지 못한 상태인데, 추후 테스트 컨테이너를 구성하여 일관적인 환경에서 테스트하는 것이 바람직해 보입니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항

> 테스트는 대다수 통과하였지만 급한 수정으로 인해 누락된 부분이 있을 수 있습니다. 꼼꼼한 리뷰 부탁드립니다:)