### PR TITLE
[feat] 추첨 이벤트 참여 관련 api 구현(#51)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
@@ -40,7 +40,7 @@ public class DrawEventFieldMapper implements EventFieldMapper {
         if (dto == null) throw new EventException(ErrorCode.INVALID_JSON);
 
         DrawEvent event = new DrawEvent();
-        metadata.addDrawEvent(event);
+        metadata.updateDrawEvent(event);
         event.setEventMetadata(metadata);
 
         List<DrawEventScorePolicy> policies = dto.getPolicies().stream().map(
@@ -65,37 +65,36 @@ public class DrawEventFieldMapper implements EventFieldMapper {
 
     @Override
     public void fetchToDto(EventMetadata metadata, EventDto eventDto) {
-        Optional<DrawEvent> drawEventOpt = metadata.getDrawEventList().stream().findFirst();
+       DrawEvent drawEvent = metadata.getDrawEvent();
         // drawEvent 정보가 있으면 넣기
-        drawEventOpt.ifPresent(drawEvent -> {
-            DrawEventDto drawEventDto = DrawEventDto
-                    .builder()
-                    .id(drawEvent.getId())
-                    .metadata(drawEvent.getMetadataList().stream().map(
-                            it -> DrawEventMetadataDto.builder()
-                                    .id(it.getId())
-                                    .count(it.getCount())
-                                    .grade(it.getGrade())
-                                    .prizeInfo(it.getPrizeInfo())
-                                    .build()
-                    ).toList())
-                    .policies(drawEvent.getPolicyList().stream().map(
-                            it -> DrawEventScorePolicyDto.builder()
-                                    .id(it.getId())
-                                    .score(it.getScore())
-                                    .action(it.getAction())
-                                    .build()
-                    ).toList())
-                    .build();
+        if(drawEvent == null) throw new EventException(ErrorCode.INVALID_JSON);
+        DrawEventDto drawEventDto = DrawEventDto
+                .builder()
+                .id(drawEvent.getId())
+                .metadata(drawEvent.getMetadataList().stream().map(
+                        it -> DrawEventMetadataDto.builder()
+                                .id(it.getId())
+                                .count(it.getCount())
+                                .grade(it.getGrade())
+                            .prizeInfo(it.getPrizeInfo())
+                            .build()
+            ).toList())
+            .policies(drawEvent.getPolicyList().stream().map(
+                    it -> DrawEventScorePolicyDto.builder()
+                            .id(it.getId())
+                            .score(it.getScore())
+                            .action(it.getAction())
+                            .build()
+            ).toList())
+            .build();
 
             eventDto.setDraw(drawEventDto);
-        });
     }
 
     @Override
     public void editEventField(EventMetadata metadata, EventDto dto) {
-        Optional<DrawEvent> drawEventOpt = metadata.getDrawEventList().stream().findFirst();
-        DrawEvent drawEvent = drawEventOpt.orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        DrawEvent drawEvent = metadata.getDrawEvent();
+        if(drawEvent == null) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
         DrawEventDto drawEventDto = dto.getDraw();
 
         editDrawEventMetadata(drawEvent, drawEventDto);

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -73,11 +73,11 @@ public class EventMetadata {
     @JoinColumn(name="event_frame_id")
     private EventFrame eventFrame;
 
-    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private final List<DrawEvent> drawEventList = new ArrayList<>();
+    @OneToOne(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    private DrawEvent drawEvent;
 
-    public void addDrawEvent(DrawEvent drawEvent) {
-        this.drawEventList.add(drawEvent);
+    public void updateDrawEvent(DrawEvent drawEvent) {
+        this.drawEvent = drawEvent;
     }
 
     @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
@@ -1,0 +1,65 @@
+package hyundai.softeer.orange.event.draw.controller;
+
+import hyundai.softeer.orange.common.ErrorResponse;
+import hyundai.softeer.orange.core.auth.Auth;
+import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.event.draw.dto.EventParticipationDatesDto;
+import hyundai.softeer.orange.event.draw.service.EventParticipationService;
+import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
+import hyundai.softeer.orange.eventuser.dto.EventUserInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/event/draw")
+@RestController
+@Auth({AuthRole.event_user})
+public class DrawEventController {
+    private static final Logger log = LoggerFactory.getLogger(DrawEventController.class);
+    private final EventParticipationService epService;
+
+    /**
+     *
+     * @param eventId 이벤트의 id
+     */
+    @Operation(summary = "오늘의 인터렉션 이벤트에 참여한다.", description = "오늘의 인터렉션 이벤트에 참여한다. 서버 시간 기준으로 참여를 정하며, 당일 중복 참여는 불가능하다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트 참여 기록 획득"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이미 이벤트에 참여함", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/{eventId}/participation")
+    public ResponseEntity<Void> participateDailyEvent(
+            @PathVariable ("eventId") String eventId,
+            @Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo
+    ) {
+        epService.participateDaily(eventId, userInfo.getUserId());
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     *
+     * @param eventId 이벤트의 id
+     * @return 유저의 이벤트 참여 정보
+     */
+    @Operation(summary = "이벤트 참여일자 목록을 얻는다.", description = "이벤트 유저의 대상 이벤트 참여일자 목록을 얻는다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트 참여 기록 획득"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/{eventId}/participation")
+    public ResponseEntity<EventParticipationDatesDto> getParticipationDates(
+            @PathVariable ("eventId") String eventId,
+            @Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo
+    ) {
+        EventParticipationDatesDto dto = epService.getParticipationDateList(eventId, userInfo.getUserId());
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
@@ -1,0 +1,5 @@
+package hyundai.softeer.orange.event.draw.dto;
+
+import java.time.LocalDateTime;
+
+public record EventParticipationDateDto(LocalDateTime date) {}

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
@@ -2,4 +2,6 @@ package hyundai.softeer.orange.event.draw.dto;
 
 import java.time.LocalDateTime;
 
-public record EventParticipationDateDto(LocalDateTime date) {}
+public interface EventParticipationDateDto{
+    LocalDateTime getDate();
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDatesDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDatesDto.java
@@ -1,0 +1,6 @@
+package hyundai.softeer.orange.event.draw.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EventParticipationDatesDto(List<LocalDateTime> dates) {}

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -18,7 +18,7 @@ public class DrawEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_metadata_id")
     private EventMetadata eventMetadata;
 

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/EventParticipationInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/EventParticipationInfo.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Table(name="event_partication_info")
+@Table(name="event_participation_info")
 @Getter
 @Entity
 public class EventParticipationInfo {
@@ -24,4 +24,12 @@ public class EventParticipationInfo {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="draw_event_id")
     private DrawEvent drawEvent;
+
+    public static EventParticipationInfo of(LocalDateTime date, EventUser eventUser, DrawEvent drawEvent) {
+        EventParticipationInfo participationInfo = new EventParticipationInfo();
+        participationInfo.date = date;
+        participationInfo.eventUser = eventUser;
+        participationInfo.drawEvent = drawEvent;
+        return participationInfo;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
@@ -2,7 +2,9 @@ package hyundai.softeer.orange.event.draw.repository;
 
 import hyundai.softeer.orange.event.draw.dto.EventParticipateCountDto;
 import hyundai.softeer.orange.event.draw.dto.EventParticipationDateDto;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import hyundai.softeer.orange.event.draw.entity.EventParticipationInfo;
+import hyundai.softeer.orange.eventuser.entity.EventUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,14 +27,5 @@ public interface EventParticipationInfoRepository extends JpaRepository<EventPar
             "AND info.draw_event_id = :drawEventId", nativeQuery = true)
     List<EventParticipationDateDto> findByEventUserId(@Param("eventUserId") String eventUserId, @Param("drawEventId") Long drawEventId);
 
-
-    // boolean / exists를 시도했으나 실패. 개발이 어느 정도 진행된 이후 처리할 예정.
-    @Query(value = "SELECT COUNT(*) "+
-            "FROM event_participation_info info " +
-            "JOIN event_user e ON info.event_user_id = e.id " +
-            "WHERE e.user_id = :eventUserId " +
-            "AND info.draw_event_id = :drawEventId " +
-            "AND info.date BETWEEN :from AND :to " +
-            "limit 1", nativeQuery = true)
-    Long count1ByUserId(@Param("eventUserId") String eventUserId, @Param("drawEventId") Long drawEventId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+    boolean existsByEventUserAndDrawEventAndDateBetween(EventUser eventUser, DrawEvent drawEvent, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
@@ -1,18 +1,38 @@
 package hyundai.softeer.orange.event.draw.repository;
 
 import hyundai.softeer.orange.event.draw.dto.EventParticipateCountDto;
+import hyundai.softeer.orange.event.draw.dto.EventParticipationDateDto;
 import hyundai.softeer.orange.event.draw.entity.EventParticipationInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface EventParticipationInfoRepository extends JpaRepository<EventParticipationInfo, Long> {
     @Query(value = "SELECT event_user_id as eventUserId, COUNT(event_user_id) as count " +
-            "FROM event_partication_info " +
+            "FROM event_participation_info " +
             "WHERE draw_event_id = :eventRawId " +
             "GROUP BY event_user_id", nativeQuery = true)
     List<EventParticipateCountDto> countPerEventUserByEventId(Long eventRawId);
+
+    @Query(value = "SELECT info.date as date FROM event_participation_info info " +
+            "JOIN event_user e ON info.event_user_id =  e.id " +
+            "WHERE e.user_id = :eventUserId " +
+            "AND info.draw_event_id = :drawEventId", nativeQuery = true)
+    List<EventParticipationDateDto> findByEventUserId(@Param("eventUserId") String eventUserId, @Param("drawEventId") Long drawEventId);
+
+
+    // boolean / exists를 시도했으나 실패. 개발이 어느 정도 진행된 이후 처리할 예정.
+    @Query(value = "SELECT COUNT(*) "+
+            "FROM event_participation_info info " +
+            "JOIN event_user e ON info.event_user_id = e.id " +
+            "WHERE e.user_id = :eventUserId " +
+            "AND info.draw_event_id = :drawEventId " +
+            "AND info.date BETWEEN :from AND :to " +
+            "limit 1", nativeQuery = true)
+    Long count1ByUserId(@Param("eventUserId") String eventUserId, @Param("drawEventId") Long drawEventId, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
@@ -1,0 +1,99 @@
+package hyundai.softeer.orange.event.draw.service;
+
+import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.common.exception.EventException;
+import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
+import hyundai.softeer.orange.event.draw.dto.EventParticipationDateDto;
+import hyundai.softeer.orange.event.draw.dto.EventParticipationDatesDto;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import hyundai.softeer.orange.event.draw.entity.EventParticipationInfo;
+import hyundai.softeer.orange.event.draw.repository.EventParticipationInfoRepository;
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import hyundai.softeer.orange.eventuser.exception.EventUserException;
+import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 이벤트 참여 정보와 관련된 기능을 처리하는 부분
+ */
+@RequiredArgsConstructor
+@Service
+public class EventParticipationService {
+    private final EventParticipationInfoRepository participationInfoRepository;
+    private final EventMetadataRepository emRepository;
+    private final EventUserRepository eventUserRepository;
+
+    /**
+     * 이벤트 유저가 참여한 이벤트 날짜 목록을 반환한다.
+     * @param eventUserId 이벤트 유저의 id
+     * @return 이벤트 유저가 추첨 이벤트에 참여한 날짜 목록
+     */
+    @Transactional(readOnly = true)
+    public EventParticipationDatesDto getParticipationDateList(String eventId, String eventUserId) {
+        // 이벤트 존재 여부 검증
+        EventMetadata event = emRepository.findFirstByEventId(eventId)
+                .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+
+        if(event.getEventType() != EventType.draw) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
+        DrawEvent drawEvent = event.getDrawEvent();
+        if(drawEvent == null) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
+
+        List<EventParticipationDateDto> infos = participationInfoRepository.findByEventUserId(eventUserId, drawEvent.getId());
+
+        return new EventParticipationDatesDto(infos.stream().map(EventParticipationDateDto::date).toList());
+    }
+
+    /**
+     * 오늘의 추첨 이벤트에 참여한다
+     * @param eventId 참여하는 이벤트
+     * @param eventUserId 이벤트 유저의 id
+     */
+    @Transactional
+    public void participateDaily(String eventId, String eventUserId) {
+        participateAtDate(eventId, eventUserId, LocalDateTime.now());
+    }
+
+    /**
+     * 오늘의 추첨 이벤트에 참여한다
+     * @param eventId 참여하는 이벤트
+     * @param eventUserId 이벤트 유저의 id
+     * @param date 이벤트에 참여하는 날짜.
+     */
+    private void participateAtDate(String eventId, String eventUserId, LocalDateTime date) {
+        // 이벤트가 존재하는지 검사
+        EventMetadata event = emRepository.findFirstByEventId(eventId)
+                .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+
+        if(event.getEventType() != EventType.draw) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
+
+        DrawEvent drawEvent = event.getDrawEvent();
+        EventUser eventUser = eventUserRepository.findByUserId(eventUserId)
+                .orElseThrow(() -> new EventUserException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDate today = date.toLocalDate();
+
+        // 이벤트 기간 안에 있는지 검사
+        if(event.getStartTime().isAfter(date) || event.getEndTime().isBefore(date))
+            throw new EventException(ErrorCode.INVALID_EVENT_TYPE);
+
+        // 오늘 시작 / 끝 시간
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+
+        // 오늘 참여 여부 검사
+        boolean alreadyParticipated = participationInfoRepository.count1ByUserId(eventUserId, drawEvent.getId(), startOfDay, endOfDay) > 0;
+        if(alreadyParticipated) throw new EventException(ErrorCode.ALREADY_PARTICIPATED);
+
+        EventParticipationInfo info = EventParticipationInfo.of(date, eventUser, drawEvent);
+        participationInfoRepository.save(info);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
@@ -68,7 +68,7 @@ public class EventParticipationService {
      * @param eventUserId 이벤트 유저의 id
      * @param date 이벤트에 참여하는 날짜.
      */
-    private void participateAtDate(String eventId, String eventUserId, LocalDateTime date) {
+    protected void participateAtDate(String eventId, String eventUserId, LocalDateTime date) {
         // 이벤트가 존재하는지 검사
         EventMetadata event = emRepository.findFirstByEventId(eventId)
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
@@ -76,6 +76,7 @@ public class EventParticipationService {
         if(event.getEventType() != EventType.draw) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
 
         DrawEvent drawEvent = event.getDrawEvent();
+
         EventUser eventUser = eventUserRepository.findByUserId(eventUserId)
                 .orElseThrow(() -> new EventUserException(ErrorCode.USER_NOT_FOUND));
 
@@ -83,7 +84,7 @@ public class EventParticipationService {
 
         // 이벤트 기간 안에 있는지 검사
         if(event.getStartTime().isAfter(date) || event.getEndTime().isBefore(date))
-            throw new EventException(ErrorCode.INVALID_EVENT_TYPE);
+            throw new EventException(ErrorCode.INVALID_EVENT_TIME);
 
         // 오늘 시작 / 끝 시간
         LocalDateTime startOfDay = today.atStartOfDay();

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
@@ -49,7 +49,7 @@ public class EventParticipationService {
 
         List<EventParticipationDateDto> infos = participationInfoRepository.findByEventUserId(eventUserId, drawEvent.getId());
 
-        return new EventParticipationDatesDto(infos.stream().map(EventParticipationDateDto::date).toList());
+        return new EventParticipationDatesDto(infos.stream().map(EventParticipationDateDto::getDate).toList());
     }
 
     /**
@@ -90,7 +90,7 @@ public class EventParticipationService {
         LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
 
         // 오늘 참여 여부 검사
-        boolean alreadyParticipated = participationInfoRepository.count1ByUserId(eventUserId, drawEvent.getId(), startOfDay, endOfDay) > 0;
+        boolean alreadyParticipated = participationInfoRepository.existsByEventUserAndDrawEventAndDateBetween(eventUser, drawEvent, startOfDay, endOfDay);
         if(alreadyParticipated) throw new EventException(ErrorCode.ALREADY_PARTICIPATED);
 
         EventParticipationInfo info = EventParticipationInfo.of(date, eventUser, drawEvent);

--- a/src/test/java/hyundai/softeer/orange/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/repository/CommentRepositoryTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 // 매 테스트마다 초기화하는 코드 찾아봐야 할듯?
 @Sql(value = "classpath:sql/CommentRepositoryTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+@Sql(value= "classpath:sql/RefreshTable.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_CLASS)
 @DataJpaTest(showSql = false)
 @TestPropertySource(locations = "classpath:application-test.yml")
 class CommentRepositoryTest {

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
@@ -71,14 +71,12 @@ class DrawEventFieldMapperTest {
 
         mapper.fetchToEventEntity(metadata, dto);
 
-        var drawEvents = metadata.getDrawEventList();
-        var drawEvent = drawEvents.get(0);
+        var drawEvent = metadata.getDrawEvent();
         var drawEventMetadata = drawEvent.getMetadataList();
         var oneDrawMetadata = drawEventMetadata.get(0);
         var drawEventPolicies  = drawEvent.getPolicyList();
         var oneEventPolicy = drawEventPolicies.get(0);
 
-        assertThat(drawEvents).isNotNull().hasSize(1);
         assertThat(drawEventMetadata).isNotNull().hasSize(1);
         assertThat(drawEventPolicies).isNotNull().hasSize(1);
         // 부모 자식 관계 잘 설정하는지

--- a/src/test/java/hyundai/softeer/orange/event/draw/repository/CustomDrawEventWinningInfoRepositoryImplTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/repository/CustomDrawEventWinningInfoRepositoryImplTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 @Sql(value="classpath:sql/CustomDrawEventWinningInfoRepositoryImplTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+@Sql(value= "classpath:sql/RefreshTable.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_CLASS)
 @DataJpaTest(showSql = false)
 @TestPropertySource(locations = "classpath:application-test.yml")
 class CustomDrawEventWinningInfoRepositoryImplTest {

--- a/src/test/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepositoryTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepositoryTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.jdbc.Sql;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql(value = "classpath:sql/EventParticipationInfoRepositoryTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+@Sql(value= "classpath:sql/RefreshTable.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_CLASS)
 @DataJpaTest(showSql = false)
 @TestPropertySource(locations = "classpath:application-test.yml")
 class EventParticipationInfoRepositoryTest {

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
@@ -1,0 +1,247 @@
+package hyundai.softeer.orange.event.draw.service;
+
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.common.exception.EventException;
+import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
+import hyundai.softeer.orange.event.draw.dto.EventParticipationDateDto;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import hyundai.softeer.orange.event.draw.repository.EventParticipationInfoRepository;
+
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import hyundai.softeer.orange.eventuser.exception.EventUserException;
+import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+class EventParticipationServiceTest {
+    @DisplayName("이벤트가 존재하지 않으면 예외 반환")
+    @Test
+    void getParticipationDateList_throwIfEventNotExist() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.empty());
+//        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+//        EventUserRepository euRepository = mock(EventUserRepository.class);
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.getParticipationDateList("test", "any");
+        });
+    }
+
+    @DisplayName("이벤트가 존재해도, draw 이벤트가 아니면 예외 반환")
+    @Test
+    void getParticipationDateList_EventIsNotDraw() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder().eventType(EventType.fcfs).build()
+        ));
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.getParticipationDateList("test", "any");
+        });
+    }
+
+    @DisplayName("이벤트가 draw 이벤트여도 drawEvent == null이면 예외 반환")
+    @Test
+    void getParticipationDateList_EventIsDrawButDrawEventIsNull() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder().eventType(EventType.draw).build()
+        ));
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.getParticipationDateList("test", "any");
+        });
+    }
+
+    @DisplayName("정상적인 이벤트라면 참여 기록 반환")
+    @Test
+    void getParticipationDateList_returnParticipationInfos() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder()
+                        .eventType(EventType.draw)
+                        .drawEvent(new DrawEvent())
+                        .build()
+        ));
+        var mockDto1 = mock(EventParticipationDateDto.class);
+        var mockDto2 = mock(EventParticipationDateDto.class);
+        when(mockDto1.getDate()).thenReturn(LocalDateTime.now());
+        when(mockDto2.getDate()).thenReturn(LocalDateTime.now());
+
+
+        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+        when(epiRepository.findByEventUserId(any(), any())).thenReturn(List.of(mockDto1, mockDto2));
+
+        EventParticipationService service = new EventParticipationService(epiRepository, emRepository, null);
+        var list = service.getParticipationDateList("test", "test");
+        assertThat(list).isNotNull();
+        assertThat(list.dates()).hasSize(2);
+    }
+
+    @DisplayName("이벤트가 존재하지 않으면 예외 반환")
+    @Test
+    void participateAtDaily_throwIfEventNotExist() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.empty());
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.participateDaily("test", "any");
+        });
+    }
+
+    @DisplayName("이벤트가 존재해도, draw 이벤트가 아니면 예외 반환")
+    @Test
+    void participateAtDaily_EventIsNotDraw() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder().eventType(EventType.fcfs).build()
+        ));
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.participateDaily("test", "any");
+        });
+        verify(emRepository, atLeastOnce()).findFirstByEventId(any());
+    }
+
+    @DisplayName("이벤트가 draw 이벤트여도 drawEvent == null이면 예외 반환")
+    @Test
+    void participateDaily_EventIsDrawButDrawEventIsNull() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder().eventType(EventType.draw).build()
+        ));
+
+        EventParticipationService service = new EventParticipationService(null, emRepository, null);
+
+        assertThatThrownBy(() -> {
+            service.participateDaily("test", "any");
+        });
+    }
+
+    @DisplayName("이벤트 유저가 없다면 예외 반환")
+    @Test
+    void participateDaily_throwIfNotEventTime() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder()
+                        .eventType(EventType.draw)
+                        .drawEvent(new DrawEvent())
+                        .build()
+        ));
+        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+
+        EventUserRepository euRepository = mock(EventUserRepository.class);
+        when(euRepository.findByUserId(any())).thenReturn(Optional.empty());
+
+        EventParticipationService service = new EventParticipationService(epiRepository, emRepository, euRepository);
+        assertThatThrownBy(() -> {
+            service.participateDaily("test", "any");
+        }).isInstanceOf(EventUserException.class);
+        verify(euRepository, atLeastOnce()).findByUserId(any());
+    }
+
+    @DisplayName("이벤트 유저가 있을 때 이벤트 기간이 지났으면 예외 반환")
+    @Test
+    void participateAtDate_throwIfNotEventTime() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder()
+                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
+                        .endTime(LocalDateTime.of(2024,8,10,0,0,0))
+                        .eventType(EventType.draw)
+                        .drawEvent(new DrawEvent())
+                        .build()
+        ));
+        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+
+        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+
+        EventUserRepository euRepository = mock(EventUserRepository.class);
+        // 유저 있음
+        when(euRepository.findByUserId(any())).thenReturn(Optional.of(mock(EventUser.class)));
+
+        EventParticipationService service = new EventParticipationService(epiRepository, emRepository, euRepository);
+        assertThatThrownBy(() -> {
+            service.participateAtDate("test", "any", now);
+        }).isInstanceOf(EventException.class);
+        verify(epiRepository, never()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+    }
+
+    @DisplayName("오늘 참여했다면 예외 반환")
+    @Test
+    void participateAtDate_throwIfAlreadyParticipated() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder()
+                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
+                        .endTime(LocalDateTime.of(2024,9,2,0,0,0))
+                        .eventType(EventType.draw)
+                        .drawEvent(new DrawEvent())
+                        .build()
+        ));
+        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+
+        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+        // 오늘 참여함
+        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any())).thenReturn(true);
+
+        EventUserRepository euRepository = mock(EventUserRepository.class);
+        // 유저 있음
+        when(euRepository.findByUserId(any())).thenReturn(Optional.of(mock(EventUser.class)));
+
+        EventParticipationService service = new EventParticipationService(epiRepository, emRepository, euRepository);
+        assertThatThrownBy(() -> {
+            service.participateAtDate("test", "any", now);
+        }).isInstanceOf(EventException.class);
+        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+    }
+
+    @DisplayName("오늘 처음 참여했다면 정상적으로 참여")
+    @Test
+    void participateAtDate_participateSuccessfully() {
+        EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
+                EventMetadata.builder()
+                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
+                        .endTime(LocalDateTime.of(2024,9,2,0,0,0))
+                        .eventType(EventType.draw)
+                        .drawEvent(new DrawEvent())
+                        .build()
+        ));
+        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+
+        EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
+        // 오늘 참여함
+        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any())).thenReturn(false);
+
+        EventUserRepository euRepository = mock(EventUserRepository.class);
+        // 유저 있음
+        when(euRepository.findByUserId(any())).thenReturn(Optional.of(mock(EventUser.class)));
+
+        EventParticipationService service = new EventParticipationService(epiRepository, emRepository, euRepository);
+        service.participateAtDate("test", "any", now);
+        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+        verify(epiRepository, atLeastOnce()).save(any());
+    }
+}

--- a/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
+++ b/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
@@ -13,16 +13,16 @@ INSERT INTO event_user(score, event_frame_id, user_id) VALUES (0, 1, 'user2');
 INSERT INTO event_user(score, event_frame_id, user_id) VALUES (0, 1, 'user3');
 INSERT INTO event_user(score, event_frame_id, user_id) VALUES (0, 3, 'user4');
 
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,1);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,1);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,1);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,1);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,1);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,1);
 
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
-INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
+INSERT INTO event_participation_info(draw_event_id, event_user_id) VALUES (1,2);
 
 INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,3);
 INSERT INTO event_partication_info(draw_event_id, event_user_id) VALUES (1,3);

--- a/src/test/resources/sql/RefreshTable.sql
+++ b/src/test/resources/sql/RefreshTable.sql
@@ -1,13 +1,16 @@
+TRUNCATE TABLE url;
+TRUNCATE TABLE admin_user;
 
+TRUNCATE TABLE draw_event_score_policy;
+TRUNCATE TABLE draw_event_metadata;
+TRUNCATE TABLE draw_event_winning_info;
+TRUNCATE TABLE event_participation_info;
+TRUNCATE TABLE draw_event;
 
-DELETE FROM fcfs_event_winning_info;
-DELETE FROM fcfs_event;
+TRUNCATE TABLE fcfs_event_winning_info;
+TRUNCATE TABLE fcfs_event;
+TRUNCATE TABLE comment;
+TRUNCATE TABLE event_user;
+TRUNCATE TABLE event_metadata;
+TRUNCATE TABLE event_frame;
 
-DELETE FROM event_partication_info;
-
-DELETE FROM draw_event_score_policy;
-DELETE FROM draw_event_metadata;
-DELETE FROM draw_event_winning_info;
-DELETE FROM draw_event;
-
-DELETE FROM


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #51

# 📝 작업 내용

> 이벤트 유저가 추첨 인터렉션 이벤트에 참여하고, 참여 기록을 받아올 수 있도록 기능을 구현했습니다.

