### PR TITLE
[fix] 더미 데이터 생성 및 주요 API 로컬에서 검증 (#54)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
@@ -9,14 +9,13 @@ package hyundai.softeer.orange.admin.controller;
  import io.swagger.v3.oas.annotations.media.Content;
  import io.swagger.v3.oas.annotations.media.Schema;
  import io.swagger.v3.oas.annotations.responses.ApiResponse;
- import io.swagger.v3.oas.annotations.tags.Tag;
  import jakarta.validation.Valid;
  import lombok.RequiredArgsConstructor;
  import org.springframework.http.HttpStatus;
  import org.springframework.http.ResponseEntity;
  import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "AdminAuth", description = "어드민 인증 관련 API")
+
 @RequestMapping("/api/v1/admin/auth")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
@@ -9,12 +9,14 @@ package hyundai.softeer.orange.admin.controller;
  import io.swagger.v3.oas.annotations.media.Content;
  import io.swagger.v3.oas.annotations.media.Schema;
  import io.swagger.v3.oas.annotations.responses.ApiResponse;
+ import io.swagger.v3.oas.annotations.tags.Tag;
  import jakarta.validation.Valid;
  import lombok.RequiredArgsConstructor;
  import org.springframework.http.HttpStatus;
  import org.springframework.http.ResponseEntity;
  import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "AdminAuth", description = "어드민 인증 관련 API")
 @RequestMapping("/api/v1/admin/auth")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -6,13 +6,12 @@ import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "AdminComment", description = "어드민 댓글 관련 API")
+
 @RequestMapping("/api/v1/admin/comments")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -5,15 +5,14 @@ import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "AdminComment", description = "어드민 댓글 관련 API")
 @RequestMapping("/api/v1/admin/comments")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -2,7 +2,6 @@ package hyundai.softeer.orange.comment.controller;
 
 import hyundai.softeer.orange.comment.dto.CreateCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
-import hyundai.softeer.orange.comment.service.ApiService;
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
@@ -29,7 +28,6 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
-    private final ApiService apiService;
 
     @Tag(name = "Comment")
     @GetMapping("/{eventFrameId}")
@@ -55,8 +53,7 @@ public class CommentController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Boolean> createComment(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
-        boolean isPositive = apiService.analyzeComment(dto.getContent());
-        return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto, isPositive));
+        return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto));
     }
 
     @Auth(AuthRole.event_user)

--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -10,6 +10,7 @@ import hyundai.softeer.orange.core.auth.AuthRole;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
 import hyundai.softeer.orange.eventuser.dto.EventUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -53,7 +54,7 @@ public class CommentController {
             @ApiResponse(responseCode = "409", description = "하루에 여러 번의 기대평을 작성하려 할 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> createComment(@EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
+    public ResponseEntity<Boolean> createComment(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
         boolean isPositive = apiService.analyzeComment(dto.getContent());
         return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto, isPositive));
     }
@@ -67,7 +68,7 @@ public class CommentController {
             @ApiResponse(responseCode = "404", description = "해당 정보를 갖는 유저가 존재하지 않을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> isCommentable(@EventUserAnnotation EventUserInfo userInfo) {
+    public ResponseEntity<Boolean> isCommentable(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo) {
         return ResponseEntity.ok(commentService.isCommentable(userInfo.getUserId()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
@@ -16,6 +18,14 @@ public class ResponseCommentDto {
     private String content;
     private String userName;
     private String createdAt;
+
+    // CommentRepository에서 Projection으로 ResponseCommentDto를 생성할 때 사용, 추후 더 나은 방법으로 수정 필요
+    public ResponseCommentDto(Long id, String content, String userName, LocalDateTime createdAt) {
+        this.id = id;
+        this.content = content;
+        this.userName = userName;
+        this.createdAt = createdAt.toString();
+    }
 
     public static ResponseCommentDto from(Comment comment) {
         return ResponseCommentDto.builder()

--- a/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
@@ -17,14 +16,14 @@ public class ResponseCommentDto {
     private Long id;
     private String content;
     private String userName;
-    private String createdAt;
+    private LocalDateTime createdAt;
 
     // CommentRepository에서 Projection으로 ResponseCommentDto를 생성할 때 사용, 추후 더 나은 방법으로 수정 필요
     public ResponseCommentDto(Long id, String content, String userName, LocalDateTime createdAt) {
         this.id = id;
         this.content = content;
         this.userName = userName;
-        this.createdAt = createdAt.toString();
+        this.createdAt = createdAt;
     }
 
     public static ResponseCommentDto from(Comment comment) {
@@ -32,7 +31,7 @@ public class ResponseCommentDto {
                 .id(comment.getId())
                 .content(comment.getContent())
                 .userName(comment.getEventUser().getUserName())
-                .createdAt(comment.getCreatedAt().toString())
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -16,8 +16,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "SELECT * FROM comment WHERE event_frame_id = :eventFrameId AND is_positive = true ORDER BY RAND() LIMIT :n", nativeQuery = true)
     List<Comment> findRandomPositiveComments(Long eventFrameId, @Param("n") int n);
 
-    // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인
-    @Query(value = "SELECT COUNT(*) FROM comment WHERE event_user_id = :eventUserId AND DATE(createdAt) = CURDATE()", nativeQuery = true)
+    // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인 (JPQL)
+    @Query("SELECT (COUNT(c) > 0) FROM Comment c WHERE c.eventUser.id = :eventUserId AND FUNCTION('DATE', c.createdAt) = CURRENT_DATE")
     boolean existsByCreatedDateAndEventUser(@Param("eventUserId") Long eventUserId);
 
     @Query(value = "SELECT c.* FROM comment c " +

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.comment.repository;
 
+import hyundai.softeer.orange.comment.dto.ResponseCommentDto;
 import hyundai.softeer.orange.comment.dto.WriteCommentCountDto;
 import hyundai.softeer.orange.comment.entity.Comment;
 import org.springframework.data.domain.Page;
@@ -12,9 +13,13 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-    // DB 상에서 무작위로 추출된 n개의 긍정 기대평 목록을 조회
-    @Query(value = "SELECT * FROM comment WHERE event_frame_id = :eventFrameId AND is_positive = true ORDER BY RAND() LIMIT :n", nativeQuery = true)
-    List<Comment> findRandomPositiveComments(Long eventFrameId, @Param("n") int n);
+    // DB 상에서 무작위로 추출된 n개의 긍정 기대평 목록을 조회하고 Dto로 반환, N+1 문제 방지 (JPQL)
+    @Query("select new hyundai.softeer.orange.comment.dto.ResponseCommentDto(c.id, c.content, cu.userName, c.createdAt) " +
+            "from Comment c " +
+            "JOIN c.eventUser cu " +
+            "where c.eventFrame.id = :eventFrameId and c.isPositive = true " +
+            "order by function('RAND')")
+    List<ResponseCommentDto> findRandomPositiveComments(Long eventFrameId, Pageable pageable);
 
     // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인 (JPQL)
     @Query("SELECT (COUNT(c) > 0) FROM Comment c WHERE c.eventUser.id = :eventUserId AND FUNCTION('DATE', c.createdAt) = CURRENT_DATE")

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -90,6 +90,7 @@ public class CommentService {
         log.info("deleted comments: {}", commentIds);
     }
 
+    @Transactional(readOnly = true)
     public ResponseCommentsDto searchComments(String eventId, Integer page, Integer size) {
         PageRequest pageInfo = PageRequest.of(page, size);
 

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -29,6 +29,7 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final EventFrameRepository eventFrameRepository;
     private final EventUserRepository eventUserRepository;
+    private final CommentValidator commentValidator;
 
     // 주기적으로 무작위 추출되는 긍정 기대평 목록을 조회한다.
     @Transactional(readOnly = true)
@@ -53,6 +54,8 @@ public class CommentService {
         if(commentRepository.existsByCreatedDateAndEventUser(eventUser.getId())) {
             throw new CommentException(ErrorCode.COMMENT_ALREADY_EXISTS);
         }
+
+        boolean isPositive = commentValidator.analyzeComment(dto.getContent());
 
         // TODO: 점수정책와 연계하여 기대평 등록 시 점수를 부여 추가해야함
         Comment comment = Comment.of(dto.getContent(), eventFrame, eventUser, isPositive);

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -35,11 +35,9 @@ public class CommentService {
     @Transactional(readOnly = true)
     @Cacheable(value = "comments", key = ConstantUtil.COMMENTS_KEY + " + #eventFrameId")
     public ResponseCommentsDto getComments(String eventFrameId) {
+        log.info("fetching comments of {}", eventFrameId);
         EventFrame frame = getEventFrame(eventFrameId);
-        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(frame.getId(), ConstantUtil.COMMENTS_SIZE)
-                .stream()
-                .map(ResponseCommentDto::from)
-                .toList();
+        List<ResponseCommentDto> comments = commentRepository.findRandomPositiveComments(frame.getId(), PageRequest.of(0, ConstantUtil.COMMENTS_SIZE));
         log.info("comments of {} fetched from DB to Redis", eventFrameId);
         return new ResponseCommentsDto(comments);
     }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentValidator.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentValidator.java
@@ -22,9 +22,9 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
-public class ApiService {
+public class CommentValidator {
 
-    private static final Logger log = LoggerFactory.getLogger(ApiService.class);
+    private static final Logger log = LoggerFactory.getLogger(CommentValidator.class);
     private final NaverApiConfig naverApiConfig;
 
     public boolean analyzeComment(String content) {

--- a/src/main/java/hyundai/softeer/orange/config/RedisConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/RedisConfig.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.core.ParseUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -18,9 +19,12 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
+@RequiredArgsConstructor
 @EnableCaching
 @Configuration
 public class RedisConfig {
+    private final ObjectMapper objectMapper;
+
     @Bean
     public ParseUtil parseUtil(ObjectMapper objectMapper) {
         return new ParseUtil(objectMapper);
@@ -33,7 +37,6 @@ public class RedisConfig {
         template.setKeySerializer(new StringRedisSerializer());
 
         // ObjectMapper 설정
-        ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.activateDefaultTyping(
                 objectMapper.getPolymorphicTypeValidator(),
                 ObjectMapper.DefaultTyping.NON_FINAL);
@@ -84,10 +87,10 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager diareatCacheManager(RedisConnectionFactory cf) {
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper)))
                 .entryTtl(Duration.ofMinutes(120L)); // 캐시 만료 시간 2시간
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
     }

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.List;
 /**
  * 이벤트 관련 CRUD를 다루는 API
  */
+@Tag(name = "AdminEvent", description = "어드민 이벤트 관련 API")
 @Auth({AuthRole.admin})
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +29,7 @@ import java.util.List;
 /**
  * 이벤트 관련 CRUD를 다루는 API
  */
-@Tag(name = "AdminEvent", description = "어드민 이벤트 관련 API")
+
 @Auth({AuthRole.admin})
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
@@ -12,12 +12,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "DrawEvent", description = "인터렉션 및 추첨 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/event/draw")
 @RestController

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -12,6 +12,7 @@ import hyundai.softeer.orange.event.fcfs.service.FcfsService;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
 import hyundai.softeer.orange.eventuser.dto.EventUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,7 +40,7 @@ public class FcfsController {
             @ApiResponse(responseCode = "400", description = "선착순 이벤트 시간이 아니거나, 요청 형식이 잘못된 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseFcfsResultDto> participate(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence, @RequestBody RequestAnswerDto dto) {
+    public ResponseEntity<ResponseFcfsResultDto> participate(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence, @RequestBody RequestAnswerDto dto) {
         boolean answerResult = fcfsAnswerService.judgeAnswer(eventSequence, dto.getAnswer());
         boolean isWin = answerResult && fcfsService.participate(eventSequence, userInfo.getUserId());
         return ResponseEntity.ok(new ResponseFcfsResultDto(answerResult, isWin));
@@ -66,7 +67,7 @@ public class FcfsController {
             @ApiResponse(responseCode = "404", description = "선착순 이벤트를 찾을 수 없는 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> isParticipated(@EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence) {
+    public ResponseEntity<Boolean> isParticipated(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence) {
         return ResponseEntity.ok(fcfsManageService.isParticipated(eventSequence, userInfo.getUserId()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "FCFS", description = "선착순 이벤트 관련 API")
+@Tag(name = "FcfsEvent", description = "선착순 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/event/fcfs")
 @RestController

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "fcfs", description = "선착순 이벤트 관련 API")
+@Tag(name = "FCFS", description = "선착순 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/event/fcfs")
 @RestController
@@ -32,7 +32,6 @@ public class FcfsController {
     private final FcfsManageService fcfsManageService;
 
     @Auth(AuthRole.event_user)
-    @Tag(name = "fcfs")
     @PostMapping("/{eventSequence}")
     @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패",
@@ -46,7 +45,6 @@ public class FcfsController {
         return ResponseEntity.ok(new ResponseFcfsResultDto(answerResult, isWin));
     }
 
-    @Tag(name = "fcfs")
     @GetMapping("/{eventSequence}/info")
     @Operation(summary = "특정 선착순 이벤트의 정보 조회", description = "특정 선착순 이벤트에 대한 정보(서버 기준 시각, 이벤트의 상태)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트에 대한 상태 정보",
@@ -59,7 +57,6 @@ public class FcfsController {
     }
 
     @Auth(AuthRole.event_user)
-    @Tag(name = "fcfs")
     @GetMapping("/{eventSequence}/participated")
     @Operation(summary = "선착순 이벤트 참여 여부 조회", description = "정답을 맞혀서 선착순 이벤트에 참여했는지 여부를 조회한다. (당첨은 별도)", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트의 정답을 맞혀서 참여했는지에 대한 결과",

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
@@ -7,6 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @Service
 public class FcfsAnswerService {
@@ -14,6 +16,16 @@ public class FcfsAnswerService {
     private final StringRedisTemplate stringRedisTemplate;
 
     public boolean judgeAnswer(Long eventSequence, String answer) {
+        // 잘못된 이벤트 참여 시간
+        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+        if(startTime == null) {
+            throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
+        }
+        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+            throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
+        }
+
+        // 정답 비교
         String correctAnswer = stringRedisTemplate.opsForValue().get(FcfsUtil.answerFormatting(eventSequence.toString()));
         if (correctAnswer == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Url", description = "단축 URL 관련 API")
+@Tag(name = "URL", description = "단축 URL 관련 API")
 @RequestMapping("/api/v1/url")
 @RequiredArgsConstructor
 @RestController
@@ -21,7 +21,6 @@ public class UrlController {
 
     private final UrlService urlService;
 
-    @Tag(name = "Url")
     @PostMapping("/shorten")
     @Operation(summary = "URL 단축", description = "URL을 단축하여 반환합니다.", responses = {
             @ApiResponse(responseCode = "200", description = "URL 단축 성공",
@@ -35,7 +34,6 @@ public class UrlController {
         return ResponseEntity.ok(urlService.generateUrl(originalUrl));
     }
 
-    @Tag(name = "Url")
     @GetMapping("/{shortUrl}")
     @Operation(summary = "URL 리다이렉트", description = "단축 URL을 원본 URL로 리다이렉트합니다.", responses = {
             @ApiResponse(responseCode = "302", description = "URL 리다이렉트"),

--- a/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
+++ b/src/main/java/hyundai/softeer/orange/event/url/controller/UrlController.java
@@ -31,8 +31,7 @@ public class UrlController {
             @ApiResponse(responseCode = "404", description = "유저를 찾지 못했을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String originalUrl, @RequestParam String userId){
-        // TODO: JWT 토큰으로부터 userId를 추출하여 사용하도록 추후 수정
+    public ResponseEntity<ResponseUrlDto> urlShorten(@RequestParam String originalUrl){
         return ResponseEntity.ok(urlService.generateUrl(originalUrl));
     }
 

--- a/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentControllerTest.java
@@ -6,7 +6,7 @@ import hyundai.softeer.orange.comment.dto.CreateCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.comment.exception.CommentException;
-import hyundai.softeer.orange.comment.service.ApiService;
+import hyundai.softeer.orange.comment.service.CommentValidator;
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.ErrorResponse;
@@ -49,7 +49,7 @@ class CommentControllerTest {
     private CommentService commentService;
 
     @MockBean
-    private ApiService apiService;
+    private CommentValidator commentValidator;
 
     @MockBean
     private EventUserArgumentResolver eventUserArgumentResolver;
@@ -109,8 +109,8 @@ class CommentControllerTest {
     @Test
     void createComment200Test() throws Exception {
         // given
-        when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean())).thenReturn(true);
+        when(commentValidator.analyzeComment(createCommentDto.getContent())).thenReturn(true);
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class))).thenReturn(true);
 
         // when & then
         mockMvc.perform(MockMvcRequestBuilders
@@ -126,8 +126,8 @@ class CommentControllerTest {
     @Test
     void createComment400Test() throws Exception {
         // given
-        when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentValidator.analyzeComment(createCommentDto.getContent())).thenReturn(true);
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class)))
                 .thenThrow(new CommentException(ErrorCode.INVALID_COMMENT));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.INVALID_COMMENT));
 
@@ -166,8 +166,8 @@ class CommentControllerTest {
     @Test
     void createComment404Test() throws Exception {
         // given
-        when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentValidator.analyzeComment(createCommentDto.getContent())).thenReturn(true);
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class)))
                 .thenThrow(new CommentException(ErrorCode.EVENT_USER_NOT_FOUND));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.EVENT_USER_NOT_FOUND));
 
@@ -185,8 +185,8 @@ class CommentControllerTest {
     @Test
     void createComment409Test() throws Exception {
         // given
-        when(apiService.analyzeComment(createCommentDto.getContent())).thenReturn(true);
-        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class), anyBoolean()))
+        when(commentValidator.analyzeComment(createCommentDto.getContent())).thenReturn(true);
+        when(commentService.createComment(any(), anyString(), any(CreateCommentDto.class)))
                 .thenThrow(new CommentException(ErrorCode.COMMENT_ALREADY_EXISTS));
         String responseBody = mapper.writeValueAsString(ErrorResponse.from(ErrorCode.COMMENT_ALREADY_EXISTS));
 

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -75,7 +76,7 @@ class CommentServiceTest {
                 .id(1L)
                 .content("test")
                 .userName("test")
-                .createdAt("2021-08-01")
+                .createdAt(LocalDateTime.now())
                 .build();
         given(commentRepository.findRandomPositiveComments(anyLong(), eq(pageable)))
                 .willReturn(List.of(responseCommentDto));

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -6,6 +6,7 @@ import hyundai.softeer.orange.comment.entity.Comment;
 import hyundai.softeer.orange.comment.exception.CommentException;
 import hyundai.softeer.orange.comment.repository.CommentRepository;
 import hyundai.softeer.orange.comment.service.CommentService;
+import hyundai.softeer.orange.comment.service.CommentValidator;
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
@@ -14,9 +15,12 @@ import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.PageImpl;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +34,9 @@ class CommentServiceTest {
 
     @InjectMocks
     private CommentService commentService;
+
+    @Mock
+    private CommentValidator commentValidator;
 
     @Mock
     private CommentRepository commentRepository;
@@ -89,10 +96,11 @@ class CommentServiceTest {
         given(commentRepository.existsByCreatedDateAndEventUser(any())).willReturn(false);
         given(eventFrameRepository.findByFrameId(eventFrameId)).willReturn(Optional.of(eventFrame));
         given(eventUserRepository.findByUserId(eventUser.getUserId())).willReturn(Optional.ofNullable(eventUser));
+        given(commentValidator.analyzeComment(createCommentDto.getContent())).willReturn(true);
         given(commentRepository.save(any())).willReturn(Comment.of("test", eventFrame, eventUser, true));
 
         // when
-        commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto, true);
+        commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto);
 
         // then
         verify(commentRepository, times(1)).save(any());
@@ -111,7 +119,7 @@ class CommentServiceTest {
         given(commentRepository.existsByCreatedDateAndEventUser(any())).willReturn(true);
 
         // when
-        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto, true))
+        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto))
                 .isInstanceOf(CommentException.class)
                 .hasMessage(ErrorCode.COMMENT_ALREADY_EXISTS.getMessage());
     }
@@ -124,7 +132,7 @@ class CommentServiceTest {
         given(eventFrameRepository.findByFrameId(eventFrameId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto, true))
+        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto))
                 .isInstanceOf(CommentException.class)
                 .hasMessage(ErrorCode.EVENT_FRAME_NOT_FOUND.getMessage());
     }
@@ -136,9 +144,39 @@ class CommentServiceTest {
         given(eventUserRepository.findByUserId(eventUser.getUserId())).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto, true))
+        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto))
                 .isInstanceOf(CommentException.class)
                 .hasMessage(ErrorCode.EVENT_USER_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("createComment: 기대평이 부정적인 경우 예외가 발생한다.")
+    @Test
+    void createCommentNegativeTest() {
+        // given
+        given(eventFrameRepository.findByFrameId(eventFrameId)).willReturn(Optional.of(eventFrame));
+        given(eventUserRepository.findByUserId(eventUser.getUserId())).willReturn(Optional.ofNullable(eventUser));
+        given(commentValidator.analyzeComment(createCommentDto.getContent())).willThrow(new CommentException(ErrorCode.INVALID_COMMENT));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createComment(eventUser.getUserId(), eventFrameId, createCommentDto))
+                .isInstanceOf(CommentException.class)
+                .hasMessage(ErrorCode.INVALID_COMMENT.getMessage());
+    }
+
+    @DisplayName("isCommentable: 오늘 이 유저가 기대평을 작성할 수 있는지 조회한다.")
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void isCommentableTest(boolean exists) {
+        // given
+        given(eventUserRepository.findByUserId(eventUser.getUserId())).willReturn(Optional.ofNullable(eventUser));
+        given(commentRepository.existsByCreatedDateAndEventUser(eventUser.getId())).willReturn(exists);
+
+        // when
+        Boolean isCommentable = commentService.isCommentable(eventUser.getUserId());
+
+        // then
+        assertThat(isCommentable).isEqualTo(!exists);
+        verify(commentRepository, times(1)).existsByCreatedDateAndEventUser(eventUser.getId());
     }
 
     @DisplayName("deleteComment: commentId로 기대평을 찾아 삭제한다.")
@@ -166,5 +204,20 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.deleteComment(commentId))
                 .isInstanceOf(CommentException.class)
                 .hasMessage(ErrorCode.COMMENT_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("searchComments: eventId로 기대평 목록을 조회한다.")
+    @Test
+    void searchCommentsTest() {
+        // given
+        given(commentRepository.findAllByEventId(any(), any())).willReturn(new PageImpl<>(List.of(Comment.of("test", eventFrame, eventUser, true))));
+
+        // when
+        ResponseCommentsDto dto = commentService.searchComments(eventFrameId, 0, 10);
+
+        // then
+        assertThat(dto.getComments()).hasSize(1);
+        assertThat(dto.getComments().get(0).getContent()).isEqualTo("test");
+        verify(commentRepository, times(1)).findAllByEventId(any(), any());
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #54

# 📝 작업 내용

> 어드민 기능을 제외한 API를 더미 데이터를 생성하여 로컬 DB에서 실험하였고, 에러나 N+1 문제가 발생하는 쿼리를 찾아서 보완했습니다. 그 외 API 동작을 점검하며 일부 비즈니스 로직을 수정했습니다.
>
> 또한 Redis 캐싱 로직에서 LocalDateTime 타입으로 인한 직렬화/역직렬화 문제가 발생하고 있어서 해결하였습니다.
>
> 구현 외적으로 Route 53과 가비아로 백엔드 도메인을 설정하였습니다.

- [x] Swagger tag 재정비
- [x] 기대평 조회 기능 N+1 문제 해결을 위해 쿼리 재작성
- [x] 기대평 등록 가능 여부 판정 쿼리가 에러 발생하여 수정
- [x] 선착순 이벤트 참여 시간이 아님에도 오답인 경우 정답을 판정하는 버그 수정
- [x] 네이버 감정분석 API Body String에서 JSON으로 명시적 수정
- [x] ApiService CommentValidator로 명칭 변경하고 CommentService 내부에 이관
- [x] Redis 캐싱 과정에서 ObjectMapper 외부에서 주입받도록 하여 직렬화/역직렬화 가능하도록 수정

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
> 