### PR TITLE
[chore] swagger jwt 인증기능 추가(#56)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
@@ -9,13 +9,14 @@ package hyundai.softeer.orange.admin.controller;
  import io.swagger.v3.oas.annotations.media.Content;
  import io.swagger.v3.oas.annotations.media.Schema;
  import io.swagger.v3.oas.annotations.responses.ApiResponse;
+ import io.swagger.v3.oas.annotations.tags.Tag;
  import jakarta.validation.Valid;
  import lombok.RequiredArgsConstructor;
  import org.springframework.http.HttpStatus;
  import org.springframework.http.ResponseEntity;
  import org.springframework.web.bind.annotation.*;
 
-
+@Tag(name = "admin auth", description = "어드민 인증에 사용되는 api")
 @RequestMapping("/api/v1/admin/auth")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -4,18 +4,20 @@ import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
+@Tag(name = "admin comment", description = "어드민 페이지에서 댓글 관리에 사용되는 api")
 @RequestMapping("/api/v1/admin/comments")
 @RequiredArgsConstructor
 @RestController
-@Auth({AuthRole.admin})
+@AdminAuthRequirement @Auth({AuthRole.admin})
 public class AdminCommentController {
     private final CommentService commentService;
 
@@ -38,7 +40,7 @@ public class AdminCommentController {
          return ResponseEntity.ok(comments);
     }
 
-    @Operation(summary = "관리가 댓글 목록 삭제", description = "관리자가 이벤트에 대한 댓글 목록을 삭제한다.", responses = {
+    @Operation(summary = "관리자가 댓글 목록 삭제", description = "관리자가 이벤트에 대한 댓글 목록을 삭제한다.", responses = {
             @ApiResponse(responseCode = "200", description = "댓글 삭제 성공")
     })
     @DeleteMapping

--- a/src/main/java/hyundai/softeer/orange/config/SwaggerConfig.java
+++ b/src/main/java/hyundai/softeer/orange/config/SwaggerConfig.java
@@ -1,8 +1,11 @@
 package hyundai.softeer.orange.config;
 
+import hyundai.softeer.orange.core.auth.AuthConst;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,7 +15,14 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(
+                        new Components()
+                                // 일반화 할 수 있는 방법?
+                        .addSecuritySchemes(AuthConst.ADMIN_AUTH, createAPIKeyScheme())
+                        .addSecuritySchemes(AuthConst.EVENT_USER_AUTH, createAPIKeyScheme())
+                )
+//                 모든 경로에 등록하면 안됨.
+//                .addSecurityItem(createAPIKeyRequirement())
                 .info(apiInfo());
     }
 
@@ -21,5 +31,16 @@ public class SwaggerConfig {
                 .title("Orange BE")
                 .description("Awesome Orange Back-End REST API")
                 .version("1.0.0");
+    }
+
+    private SecurityScheme createAPIKeyScheme() {
+        return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                .bearerFormat("JWT")
+                .scheme("bearer");
+    }
+
+    // 어디에 security가 필요한지 등록하는 것. 기본적으로 모든 경로에 등록됨
+    private SecurityRequirement createAPIKeyRequirement() {
+        return new SecurityRequirement().addList("Bearer Auth");
     }
 }

--- a/src/main/java/hyundai/softeer/orange/core/auth/AuthConst.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/AuthConst.java
@@ -1,0 +1,6 @@
+package hyundai.softeer.orange.core.auth;
+
+public class AuthConst {
+    public static final String ADMIN_AUTH = "Admin Auth";
+    public static final String EVENT_USER_AUTH = "Event User Auth";
+}

--- a/src/main/java/hyundai/softeer/orange/core/auth/list/AdminAuthRequirement.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/list/AdminAuthRequirement.java
@@ -1,0 +1,13 @@
+package hyundai.softeer.orange.core.auth.list;
+
+import hyundai.softeer.orange.core.auth.AuthConst;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SecurityRequirement(name = AuthConst.ADMIN_AUTH)
+public @interface AdminAuthRequirement {
+}

--- a/src/main/java/hyundai/softeer/orange/core/auth/list/EventUserAuthRequirement.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/list/EventUserAuthRequirement.java
@@ -1,0 +1,13 @@
+package hyundai.softeer.orange.core.auth.list;
+
+import hyundai.softeer.orange.core.auth.AuthConst;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@SecurityRequirement(name = AuthConst.EVENT_USER_AUTH)
+public @interface EventUserAuthRequirement {
+}

--- a/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/controller/AdminEventController.java
@@ -5,6 +5,7 @@ import hyundai.softeer.orange.admin.entity.Admin;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
 import hyundai.softeer.orange.event.common.service.EventService;
 import hyundai.softeer.orange.event.dto.BriefEventDto;
 import hyundai.softeer.orange.event.dto.EventDto;
@@ -16,6 +17,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,9 +31,9 @@ import java.util.List;
 /**
  * 이벤트 관련 CRUD를 다루는 API
  */
-
-@Auth({AuthRole.admin})
+@Tag(name = "admin event", description = "어드민 페이지에서 이벤트 관리에 사용하는 api")
 @Slf4j
+@AdminAuthRequirement @Auth({AuthRole.admin})
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/events")
 @RestController


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #56 

# 📝 작업 내용

> Swagger 문서에서 관리자 / 이벤트 유저에 대한 인증 기능을 사용할 수 있도록 설정했습니다. 프론트엔드 측의 요청사항에 맞는 태그 / operation 별 정렬 설정을 추가하여 admin 기능끼리 모여 있도록 구성했습니다.

## 참고 이미지 및 자료
현재 사용한 설정을 공유합니다.

```yml
springdoc:
  swagger-ui:
    operations-sorter: alpha
    tags-sorter: alpha
```
- operations-sorter: operation ( 각 api ) 을 정렬
- tag-sorter: 태그  별 정렬

![image](https://github.com/user-attachments/assets/510aabe7-4509-432b-b5a3-421f73fdf21f)
태그 별로 정렬되어 admin 관련 api를 한눈에 볼 수 있습니다!
![image](https://github.com/user-attachments/assets/9bf610ef-4f09-46cc-a2a0-61fb1f399cf4)
프론트엔드 개발자 분들은 어드민 인증, 사용자 인증이 필요한 위치에 대해 따로 인증이 가능합니다!

# 💬 리뷰 요구사항

혹시 어노테이션 A에 적용된 메타 어노테이션 B을 A가 적용된 메서드 또는 클래스 C에 바로 붙일 수 있는 기능을 알고 계신다면 알려주세요! 