### PR TITLE
[chore] api 변경 사항에 맞게 이벤트 dto 규격 수정(#63)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
@@ -57,7 +57,7 @@ public class FcfsEventFieldMapper implements EventFieldMapper {
                 .prizeInfo(it.getPrizeInfo())
                 .build()
         ).toList();
-        eventDto.setFcfsList(fcfsEventDtos);
+        eventDto.setFcfs(fcfsEventDtos);
     }
 
     @Override

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -54,7 +54,7 @@ public class EventService {
     @Transactional
     public void createEvent(EventDto eventDto) {
         // 1. eventframe을 찾는다. 없으면 작업이 의미 X
-        Optional<EventFrame> frameOpt = efRepository.findByName(eventDto.getTag());
+        Optional<EventFrame> frameOpt = efRepository.findByFrameId(eventDto.getEventFrameId());
         EventFrame frame = frameOpt
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_FRAME_NOT_FOUND));
 

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
@@ -8,10 +8,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -25,21 +22,23 @@ import java.util.List;
 @Getter
 public class EventDto {
     /**
-     * HD000000_000 형식으로 구성된 id 값
+     * HD000000_000 형식으로 구성된 id 값. 직접 설정할 필요 없음.
      */
     @NotNull(groups = {EventEditGroup.class})
-    String eventId;
+    private String eventId;
 
     /**
      * 이벤트의 이름
      */
     @Size(min = 1, max = 40)
+    @NotNull
     private String name;
 
     /**
      * 이벤트에 대한 설명
      */
     @Size(min = 1, max = 100)
+    @NotNull
     private String description;
 
     /**
@@ -68,28 +67,23 @@ public class EventDto {
     private EventType eventType;
 
     /**
-     * 이벤트 프레임 정보. 추후 변경될 수 있음.
+     * 이벤트 프레임 id
      */
     @NotNull
     private String eventFrameId;
 
     /**
-     * fcfs 이벤트 내용을 정의하는 부분
+     * fcfs 이벤트 내용을 정의하는 부분. eventType = fcfs일 때 설정
      */
+    @Setter
     @Valid
     private List<FcfsEventDto> fcfs;
 
     /**
-     * draw 이벤트 내용을 정의하는 부분
+     * draw 이벤트 내용을 정의하는 부분. eventType = draw일 때 설정
      */
+    @Setter
     @Valid
     private DrawEventDto draw;
 
-    public void setDraw(DrawEventDto drawEventDto) {
-        this.draw = drawEventDto;
-    }
-
-    public void setFcfs(List<FcfsEventDto> fcfsEventDtos) {
-        this.fcfs = fcfsEventDtos;
-    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
@@ -71,7 +71,7 @@ public class EventDto {
      * 이벤트 프레임 정보. 추후 변경될 수 있음.
      */
     @NotNull
-    private String tag;
+    private String eventFrameId;
 
     /**
      * fcfs 이벤트 내용을 정의하는 부분
@@ -89,7 +89,7 @@ public class EventDto {
         this.draw = drawEventDto;
     }
 
-    public void setFcfsList(List<FcfsEventDto> fcfsEventDtos) {
+    public void setFcfs(List<FcfsEventDto> fcfsEventDtos) {
         this.fcfs = fcfsEventDtos;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventDto.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Setter
 public class DrawEventDto {
     /**
-     * 추첨 이벤트의 id 값. 서버 내부적으로 사용하는 데이터.
+     * 추첨 이벤트의 id 값. 서버 내부적으로 사용하는 데이터. 직접 설정 X
      */
     private Long id;
 

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
@@ -13,7 +13,7 @@ import lombok.*;
 @Getter
 public class DrawEventMetadataDto {
     /**
-     * 추첨 이벤트 메타데이터에 대한 id 값. 서버 내부적으로 사용
+     * 추첨 이벤트 메타데이터에 대한 id 값. 서버 내부적으로 사용. 직접 설정 X
      */
     private Long id;
 

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
@@ -15,7 +15,7 @@ import lombok.*;
 @Getter
 public class DrawEventScorePolicyDto {
     /**
-     * 점수 정책의 id. 서버 내부적으로 사용하는 값
+     * 점수 정책의 id. 서버 내부적으로 사용하는 값. 직접 설정 X
      */
     private Long id;
 

--- a/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @Getter
 public class FcfsEventDto {
     /**
-     * Fcfs 이벤트의 id. 서버 db 측에서 사용하기 위한 값
+     * Fcfs 이벤트의 id. 서버 db 측에서 사용하기 위한 값. 직접 설정 X
      */
     private Long id;
 

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -58,7 +58,7 @@ class EventServiceTest {
     @Test
     void createEvent_throwErrorIFNoMatchedEventMapper() {
         EventDto eventDto = mock(EventDto.class);
-        when(eventDto.getTag()).thenReturn("testtag");
+        when(eventDto.getEventFrameId()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
         when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
 
@@ -72,7 +72,7 @@ class EventServiceTest {
     @Test
     void createEvent_presistEventMetadataSuccessfully() {
         EventDto eventDto = mock(EventDto.class);
-        when(eventDto.getTag()).thenReturn("testtag");
+        when(eventDto.getEventFrameId()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
         when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
         when(mapperMatcher.getMapper(any(EventType.class))).thenReturn(mock(FcfsEventFieldMapper.class));


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #63 

# 📝 작업 내용

1. eventdto가 변경된 요구사항에 맞게 event frame id를 기반으로 동작하도록 수정했습니다.
2. swagger 상에 fcfsList가 노출되는 문제가 있었습니다. 해당 문제는 swagger이 setFcfsList 메서드를 인식한 것이 문제로, setter의 명칭을 필드와 일치시켜 노출 문제를 해결했습니다.
3. 주석을 추가하여 동일한 dto를 사용하는 상황에서 필드를 설정해야 할지 헷갈리는 문제를 수정했습니다. 