### PR TITLE
[feat] 관리자 이벤트 검색 기능에 필터링 기능 추가(#62)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -1,4 +1,4 @@
-package hyundai.softeer.orange.event.common.controller;
+package hyundai.softeer.orange.admin.controller;
 
 import hyundai.softeer.orange.admin.component.AdminAnnotation;
 import hyundai.softeer.orange.admin.entity.Admin;

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -7,10 +7,7 @@ import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
 import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
 import hyundai.softeer.orange.event.common.service.EventService;
-import hyundai.softeer.orange.event.dto.BriefEventDto;
-import hyundai.softeer.orange.event.dto.EventDto;
-import hyundai.softeer.orange.event.dto.EventFrameCreateRequest;
-import hyundai.softeer.orange.event.dto.EventSearchHintDto;
+import hyundai.softeer.orange.event.dto.*;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -43,9 +40,10 @@ public class AdminEventController {
      *
      * @param search 검색어
      * @param sort 정렬 기준. (eventId|name|startTime|endTime|eventType)(:(asc|desc))? 패턴이 ,로 나뉘는 형태. ex) eventId,name:asc,startTime:desc
+     * @param type 선택할 이벤트의 타입 (fcfs|draw)을 ,로 나눠 표현. ex) type=fcfs,draw / 비어 있으면 모두 선택
      * @param page 페이지 번호
      * @param size 한번에 검색하는 이벤트 개수
-     * @return 요청한 이벤트 리스트
+     * @return 요청한 이벤트 리스트 및 페이지 정보
      */
     @GetMapping
     @Operation(summary = "이벤트 리스트 획득", description = "관리자가 이벤트 목록을 검색한다. 검색어, sort 기준 등을 정의할 수 있다.", responses = {
@@ -53,14 +51,15 @@ public class AdminEventController {
             @ApiResponse(responseCode = "5xx", description = "서버 내부적 에러"),
             @ApiResponse(responseCode = "4xx", description = "클라이언트 에러 (보통 page / size 값을 잘못 지정. 숫자가 아닌 경우 등) ")
     })
-    public ResponseEntity<List<BriefEventDto>> getEvents(
+    public ResponseEntity<BriefEventPageDto> getEvents(
             @RequestParam(required = false) String search,
             @RequestParam(required = false) String sort,
+            @RequestParam(required = false) String type,
             @RequestParam(required = false) Integer page,
             @RequestParam(required = false) Integer size
     ) {
-        List<BriefEventDto> events = eventService.searchEvents(search, sort, page, size);
-        return ResponseEntity.ok(events);
+        BriefEventPageDto pageDto = eventService.searchEvents(search, sort, type, page, size);
+        return ResponseEntity.ok(pageDto);
     }
 
     @PostMapping

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 사용자를 찾을 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "기대평을 찾을 수 없습니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트를 찾을 수 없습니다."),
+    TEMP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "임시 저장 된 이벤트가 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, false, "허용되지 않은 메서드입니다."),

--- a/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
@@ -1,5 +1,7 @@
 package hyundai.softeer.orange.event.common;
 
+import hyundai.softeer.orange.event.common.enums.EventType;
+
 import java.util.Set;
 
 public class EventConst {
@@ -15,4 +17,10 @@ public class EventConst {
     public static final int EVENT_DEFAULT_PAGE = 0;
     public static final int EVENT_DEFAULT_SIZE = 5;
     public static final Set<String> sortableFields = Set.of("eventId", "name", "startTime", "endTime", "eventType");
+
+    public static final String[] filterFields = {
+            EventType.fcfs.name(),
+            EventType.draw.name(),
+
+    };
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventSpecification.java
@@ -4,6 +4,8 @@ import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.enums.EventType;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.util.Set;
+
 public class EventSpecification {
 
     public static Specification<EventMetadata> searchOnName(String search) {
@@ -30,5 +32,12 @@ public class EventSpecification {
 
     public static Specification<EventMetadata> isEventTypeOf(EventType eventType) {
         return (metadata, query, cb) -> cb.equal(metadata.get("eventType"), eventType);
+    }
+
+    public static Specification<EventMetadata> isEventTypeIn(Set<EventType> types) {
+        return (metadata, query, cb) -> {
+            if (types.isEmpty() || types.size() == EventType.values().length) return cb.conjunction();
+            return metadata.get("eventType").in(types);
+        };
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -16,6 +16,7 @@ import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.common.repository.EventSpecification;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
 import hyundai.softeer.orange.event.dto.BriefEventDto;
+import hyundai.softeer.orange.event.dto.BriefEventPageDto;
 import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.EventSearchHintDto;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +29,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -179,8 +178,48 @@ public class EventService {
      * @return 매칭된 이벤트 목록
      */
     @Transactional(readOnly = true)
-    public List<BriefEventDto> searchEvents(String search, String sortQuery, Integer page, Integer size) {
+    public BriefEventPageDto searchEvents(String search, String sortQuery, String typeQuery, Integer page, Integer size) {
+        // findBy를 이용하려면 Sort와 Page를 하나로 몰아넣으면 안된다.
+        Sort sort = parseSort(sortQuery);
+        Set<EventType> types = parseTypes(typeQuery);
 
+        PageRequest pageInfo = PageRequest.of(
+                page != null ? page : EventConst.EVENT_DEFAULT_PAGE,
+                size != null ? size : EventConst.EVENT_DEFAULT_SIZE
+        );
+
+        var searchOnName = EventSpecification.searchOnName(search);
+        var searchOnEventId = EventSpecification.searchOnEventId(search);
+        var eventTypeIn = EventSpecification.isEventTypeIn(types);
+
+        Page<BriefEventDto> eventPage = emRepository.findBy(
+                searchOnName.or(searchOnEventId)
+                        .and(eventTypeIn),
+                (p) -> p.as(BriefEventDto.class)
+                        .sortBy(sort)
+                        .page(pageInfo)
+        );
+
+        return BriefEventPageDto.from(eventPage);
+    }
+
+    private Set<EventType> parseTypes(String typeQuery) {
+        Set<EventType> result = new HashSet<>();
+        if(typeQuery == null) return result;
+
+        String[] types = typeQuery.split(",");
+        for(String type : types) {
+            try {
+                EventType eventType = EventType.valueOf(type);
+                result.add(eventType);
+            } catch(Exception e) {
+                continue;
+            }
+        }
+        return result;
+    }
+
+    private Sort parseSort(String sortQuery) {
         List<Sort.Order> orders = new ArrayList<>();
         for(var entries: EventSearchQueryParser.parse(sortQuery).entrySet()){
             String field = entries.getKey();
@@ -197,24 +236,7 @@ public class EventService {
             }
         }
         // findBy를 이용하려면 Sort와 Page를 하나로 몰아넣으면 안된다.
-        Sort sort = Sort.by(orders);
-        PageRequest pageInfo = PageRequest.of(
-                page != null ? page : EventConst.EVENT_DEFAULT_PAGE,
-                size != null ? size : EventConst.EVENT_DEFAULT_SIZE
-        );
-
-        var searchOnName = EventSpecification.searchOnName(search);
-        var searchOnEventId = EventSpecification.searchOnEventId(search);
-
-        Page<BriefEventDto> eventPage = emRepository.findBy(
-                searchOnName.or(searchOnEventId),
-                (p) -> p.as(BriefEventDto.class)
-                        .sortBy(sort)
-                        .page(pageInfo)
-        );
-
-        log.info("Searched events for {}", search);
-        return eventPage.getContent();
+        return Sort.by(orders);
     }
 
     /**

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -103,7 +103,10 @@ public class EventService {
         String dto = (String) eventDtoRedisTemplate.opsForValue().get(key);
 
         log.info("Fetched temp event by {}", adminId);
-        return parseUtil.parse(dto, EventDto.class);
+        EventDto eventDto = parseUtil.parse(dto, EventDto.class);
+        if(eventDto == null) throw new EventException(ErrorCode.TEMP_EVENT_NOT_FOUND);
+
+        return eventDto;
     }
 
     /**

--- a/src/main/java/hyundai/softeer/orange/event/dto/BriefEventPageDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/BriefEventPageDto.java
@@ -1,0 +1,32 @@
+package hyundai.softeer.orange.event.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class BriefEventPageDto {
+    private List<BriefEventDto> contents;
+    /**
+     * 총 페이지 수
+     */
+    private int totalPages;
+    /**
+     * 현재 페이지 번호
+     */
+    private int number;
+    /**
+     * 페이지의 크기
+     */
+    private int size;
+
+    public static BriefEventPageDto from(Page<BriefEventDto> page) {
+        BriefEventPageDto dto = new BriefEventPageDto();
+        dto.totalPages = page.getTotalPages();
+        dto.number = page.getNumber();
+        dto.size = page.getSize();
+        dto.contents = page.getContent();
+        return dto;
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -93,21 +93,24 @@ class EventServiceSearchEventsTest {
     @DisplayName("search 없으면 모두 출력")
     @Test
     void searchEvents_findAllIfSearchIsNull() {
-        var list = eventService.searchEvents(null, null, null, null);
+        var page = eventService.searchEvents(null, null, null,null, null);
+        var list = page.getContents();
         assertThat(list).hasSize(5);
     }
 
     @DisplayName("search 있으면 매칭되는 값 출력")
     @Test
     void searchEvents_findMatchedIfSearchExists() {
-        var list = eventService.searchEvents("hyundai", null, null, null);
+        var page = eventService.searchEvents("hyundai", null, null,null, null);
+        var list = page.getContents();
         assertThat(list).hasSize(2);
     }
 
     @DisplayName("search 있더라도 매칭되는 것 없으면 아무것도 반환 안함")
     @Test
     void searchEvents_findNothingIfSearchExistsButNotMatch() {
-        var list = eventService.searchEvents("not-exist", null, null, null);
+        var page = eventService.searchEvents("not-exist", null, null,null, null);
+        var list = page.getContents();
         assertThat(list).hasSize(0);
     }
 
@@ -119,8 +122,8 @@ class EventServiceSearchEventsTest {
         // endTime은 존재, desc
         // error은 존재 X, 맞지 않는 값은 그냥 무시
 
-        var list = eventService.searchEvents(null, "startTime,endTime:desc,error", null, null);
-        BriefEventDto target = list.get(0);
+        var list = eventService.searchEvents(null, "startTime,endTime:desc,error", null,null, null);
+        BriefEventDto target = list.getContents().get(0);
 
         assertThat(target.getEventId()).isEqualTo("HD240805_002");
     }
@@ -133,7 +136,8 @@ class EventServiceSearchEventsTest {
         // endTime은 존재, desc
         // error은 존재 X, 맞지 않는 값은 그냥 무시
 
-        var list = eventService.searchEvents(null, "eventId", 1, 2);
+        var page = eventService.searchEvents(null, "eventId", null,1, 2);
+        var list = page.getContents();
 
         assertThat(list.get(0).getEventId()).isEqualTo("HD240805_003");
         assertThat(list.get(1).getEventId()).isEqualTo("HD240805_004");
@@ -142,10 +146,10 @@ class EventServiceSearchEventsTest {
     @DisplayName("여러 옵션 함께 사용도 가능")
     @Test
     void searchEvents_withMultipleOptions() {
-        var list = eventService.searchEvents("25", "endTime:desc", 1, 1);
-        BriefEventDto target = list.get(0);
+        var page = eventService.searchEvents("25", "endTime:desc", null,1, 1);
+        BriefEventDto target = page.getContents().get(0);
 
-        assertThat(list).hasSize(1);
+        assertThat(page.getContents()).hasSize(1);
         assertThat(target.getEventId()).isEqualTo("HD240805_004");
     }
 }

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -60,7 +60,7 @@ class EventServiceTest {
         EventDto eventDto = mock(EventDto.class);
         when(eventDto.getEventFrameId()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
-        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
+        when(efRepo.findByFrameId(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
 
         assertThatThrownBy(() -> {
             eventService.createEvent(eventDto);
@@ -74,7 +74,7 @@ class EventServiceTest {
         EventDto eventDto = mock(EventDto.class);
         when(eventDto.getEventFrameId()).thenReturn("testtag");
         when(eventDto.getEventType()).thenReturn(EventType.fcfs);
-        when(efRepo.findByName(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
+        when(efRepo.findByFrameId(anyString())).thenReturn(Optional.of(EventFrame.of("the-new-ioniq5","test")));
         when(mapperMatcher.getMapper(any(EventType.class))).thenReturn(mock(FcfsEventFieldMapper.class));
 
         eventService.createEvent(eventDto);

--- a/src/test/resources/sql/RefreshTable.sql
+++ b/src/test/resources/sql/RefreshTable.sql
@@ -1,3 +1,4 @@
+SET FOREIGN_KEY_CHECKS = 0;
 TRUNCATE TABLE url;
 TRUNCATE TABLE admin_user;
 
@@ -14,3 +15,19 @@ TRUNCATE TABLE event_user;
 TRUNCATE TABLE event_metadata;
 TRUNCATE TABLE event_frame;
 
+ALTER TABLE url AUTO_INCREMENT = 1;
+ALTER TABLE admin_user AUTO_INCREMENT = 1;
+
+ALTER TABLE draw_event_score_policy AUTO_INCREMENT = 1;
+ALTER TABLE draw_event_metadata AUTO_INCREMENT = 1;
+ALTER TABLE draw_event_winning_info AUTO_INCREMENT = 1;
+ALTER TABLE event_participation_info AUTO_INCREMENT = 1;
+ALTER TABLE draw_event AUTO_INCREMENT = 1;
+
+ALTER TABLE fcfs_event_winning_info AUTO_INCREMENT = 1;
+ALTER TABLE fcfs_event AUTO_INCREMENT = 1;
+ALTER TABLE comment AUTO_INCREMENT = 1;
+ALTER TABLE event_user AUTO_INCREMENT = 1;
+ALTER TABLE event_metadata AUTO_INCREMENT = 1;
+ALTER TABLE event_frame AUTO_INCREMENT = 1;
+SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #62

# 📝 작업 내용

이벤트 타입에 따라 현재 존재하는 이벤트를 필터링하는 기능을 추가했습니다. 

임시 저장된 글을 현재 작성한 글과 함께 필터링으로 불러오는 기능은 사용자 입장에서 일부 부자연스럽게 느낄 부분이 있다고 생각하여 좀 더 고민한 후 개발 방향을 결정하기로 했습니다.