### PR TITLE
[feat] 추첨 이벤트 재추첨 방지 로직 / api 구현(#67)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/OrangeApplication.java
+++ b/src/main/java/hyundai/softeer/orange/OrangeApplication.java
@@ -3,8 +3,10 @@ package hyundai.softeer.orange;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/draw")
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -1,0 +1,26 @@
+package hyundai.softeer.orange.admin.controller;
+
+import hyundai.softeer.orange.event.draw.service.DrawEventService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/draw")
+@RestController
+public class AdminDrawEventController {
+    private final DrawEventService drawEventService;
+    /**
+     * @param eventId 추첨할 이벤트 id
+     */
+    @Operation(summary = "추첨을 진행한다.", description = "현재 종료된 이벤트의 추첨을 진행한다. 추첨 결과는 기다리지 않는다.")
+    @PostMapping("{eventId}/draw")
+    public ResponseEntity<Void> drawEvent(@PathVariable("eventId") String eventId) {
+        drawEventService.draw(eventId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -16,6 +16,9 @@ public enum ErrorCode {
     INVALID_URL(HttpStatus.BAD_REQUEST, false, "유효하지 않은 URL입니다."),
     INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, false, "이벤트 시간이 아닙니다."),
     INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, false, "이벤트 타입이 지원되지 않습니다."),
+    EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, false, "이벤트가 아직 종료되지 않았습니다."),
+    EVENT_IS_DRAWING(HttpStatus.BAD_REQUEST, false, "현재 추첨이 진행되고 있는 이벤트입니다."),
+
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, false, "인증되지 않은 사용자입니다."),
@@ -49,6 +52,7 @@ public enum ErrorCode {
     ALREADY_WINNER(HttpStatus.CONFLICT, false, "이미 당첨된 사용자입니다."),
     ALREADY_PARTICIPATED(HttpStatus.CONFLICT, false, "이미 참여한 사용자입니다."),
     PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 전화번호입니다."),
+    ALREADY_DRAWN(HttpStatus.CONFLICT, false, "이미 추첨된 이벤트입니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다.");

--- a/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
@@ -7,10 +7,11 @@ import java.util.Set;
 public class EventConst {
     public static final String REDIS_KEY_PREFIX = "@event_key:";
 
-    public static final String REDIS_TEMP_EVENT_PREFIX = REDIS_KEY_PREFIX + "temp:";
-    public static String TEMP_KEY(Long userId) {
+    public static final String REDIS_TEMP_EVENT_PREFIX = REDIS_KEY_PREFIX + "temp:admin:";
+    public static String ADMIN_TEMP(Long userId) {
         return REDIS_TEMP_EVENT_PREFIX + userId;
     }
+    public static String IS_DRAWING(String eventId) {return REDIS_KEY_PREFIX + eventId + ":is_drawing";}
     public static final long TEMP_EVENT_DURATION_HOUR = 24L;
 
     // 검색 기능 관련 상수들

--- a/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/EventConst.java
@@ -13,6 +13,7 @@ public class EventConst {
     }
     public static String IS_DRAWING(String eventId) {return REDIS_KEY_PREFIX + eventId + ":is_drawing";}
     public static final long TEMP_EVENT_DURATION_HOUR = 24L;
+    public static final long DRAW_EVENT_DRAW_TIMEOUT_HOUR = 24L;
 
     // 검색 기능 관련 상수들
     public static final int EVENT_DEFAULT_PAGE = 0;

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -87,7 +87,7 @@ public class EventService {
      * @param eventDto 임시 저장하는 이벤트 정보
      */
     public void saveTempEvent(Long adminId, EventDto eventDto) {
-        String key = EventConst.TEMP_KEY(adminId);
+        String key = EventConst.ADMIN_TEMP(adminId);
         // 24시간 동안 유지.
         eventDtoRedisTemplate.opsForValue().set(key, eventDto, EventConst.TEMP_EVENT_DURATION_HOUR, TimeUnit.HOURS);
         log.info("Saved temp event by {}", adminId);
@@ -99,7 +99,7 @@ public class EventService {
      * @return 임시 저장 된 이벤트 정보
      */
     public EventDto getTempEvent(Long adminId) {
-        String key = EventConst.TEMP_KEY(adminId);
+        String key = EventConst.ADMIN_TEMP(adminId);
         String dto = (String) eventDtoRedisTemplate.opsForValue().get(key);
 
         log.info("Fetched temp event by {}", adminId);
@@ -114,7 +114,7 @@ public class EventService {
      * @param adminId 이벤트를 임시 저장한 관리자의 id
      */
     public void clearTempEvent(Long adminId) {
-        String key = EventConst.TEMP_KEY(adminId);
+        String key = EventConst.ADMIN_TEMP(adminId);
         eventDtoRedisTemplate.delete(key);
         log.info("Cleared temp event by {}", adminId);
     }

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -18,6 +18,12 @@ public class DrawEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * 현재 추첨이 끝난 상태인지 여부를 반환
+     */
+    @Column(nullable = false)
+    private boolean isDrawn = false;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_metadata_id")
     private EventMetadata eventMetadata;

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -41,7 +41,6 @@ public class DrawEvent {
     @OneToMany(mappedBy ="drawEvent")
     private List<EventParticipationInfo> participationInfoList = new ArrayList<>();
 
-
     @OneToMany(mappedBy ="drawEvent")
     private List<DrawEventWinningInfo> winningInfoList = new ArrayList<>();
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
@@ -12,4 +12,8 @@ import java.util.Optional;
 public interface DrawEventRepository extends JpaRepository<DrawEvent, Long> {
     @Query(value = "SELECT d FROM DrawEvent d WHERE d.eventMetadata.eventId = :eventId")
     Optional<DrawEvent> findByEventId(@Param("eventId") String eventId);
+
+//    @Modifying // 수정 쿼리는 Modifying 필요
+//    @Query(value = "UPDATE DrawEvent d SET d.isDrawn = true WHERE d.id = :id")
+//    void updateIsDrawnById(@Param("id") Long id);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
@@ -1,0 +1,94 @@
+package hyundai.softeer.orange.event.draw.service;
+
+import hyundai.softeer.orange.event.draw.component.picker.PickTarget;
+import hyundai.softeer.orange.event.draw.component.picker.WinnerPicker;
+import hyundai.softeer.orange.event.draw.component.score.ScoreCalculator;
+import hyundai.softeer.orange.event.draw.dto.DrawEventWinningInfoBulkInsertDto;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import hyundai.softeer.orange.event.draw.entity.DrawEventMetadata;
+import hyundai.softeer.orange.event.draw.entity.DrawEventScorePolicy;
+import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 실제 추첨 작업을 진행하는 클래스
+ */
+@RequiredArgsConstructor
+@Component
+public class DrawEventDrawMachine {
+    private final DrawEventWinningInfoRepository deWinningInfoRepository;
+    private final DrawEventRepository drawEventRepository;
+    private final WinnerPicker picker;
+    private final ScoreCalculator calculator;
+
+    @Async
+    @Transactional
+    public CompletableFuture<Void> draw(DrawEvent drawEvent) {
+        try {
+            Thread.sleep(10000);
+        } catch (Exception e) {}
+
+        long drawEventRawId = drawEvent.getId();
+        // 점수 계산. 추후 추첨 과정과 분리될 수도 있음.
+        List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();
+        var userScoreMap = calculator.calculate(drawEventRawId, policies);
+
+        // 추첨 타겟 리스트 생성
+        List<PickTarget> targets = userScoreMap.entrySet().stream()
+                .map(it -> new PickTarget(it.getKey(), it.getValue())).toList();
+
+        // 몇 등이 몇명이나 있는지 적혀 있는 정보. 등급끼리 정렬해서 1 ~ n 등 순서로 정렬
+        // 확률 높은 사람이 손해보면 안됨
+        List<DrawEventMetadata> metadataList = drawEvent.getMetadataList();
+        metadataList.sort(Comparator.comparing(DrawEventMetadata::getGrade));
+
+        // 총 당첨 인원 설정
+        long pickCount = metadataList.stream().mapToLong(DrawEventMetadata::getCount).sum();
+
+        // 당첨된 인원 구하기
+        var pickedTargets = picker.pick(targets, pickCount);
+
+        var insertTargets = makeDrawEventWinningInfo(pickedTargets, metadataList, drawEventRawId);
+        deWinningInfoRepository.insertMany(insertTargets);
+
+        drawEvent.setDrawn(true);
+        drawEventRepository.save(drawEvent);
+        // TODO: draw event 이미 추첨한 것으로 변경
+
+        return CompletableFuture.completedFuture(null);
+    }
+
+    protected List<DrawEventWinningInfoBulkInsertDto> makeDrawEventWinningInfo(List<PickTarget> pickedTargets, List<DrawEventMetadata> metadataList, Long drawEventRawId) {
+        List<DrawEventWinningInfoBulkInsertDto> insertTargets = new ArrayList<>();
+        int mdIdx = -1;
+        long remain = 0;
+        long grade = -1;
+        DrawEventMetadata metadata = null;
+
+        for(var target : pickedTargets) {
+            if(remain <= 0) {
+                mdIdx++;
+                metadata = metadataList.get(mdIdx);
+                grade = metadata.getGrade();
+                remain = metadata.getCount();
+            }
+
+            insertTargets.add(DrawEventWinningInfoBulkInsertDto.of(
+                    target.key(),
+                    grade,
+                    drawEventRawId
+            ));
+            remain--;
+        }
+        return insertTargets;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -45,12 +45,12 @@ public class DrawEventService {
         tryDraw(key);
 
         machine.draw(drawEvent)
-                // 예외가 발생하더라도 추첨이 끝나면 키를 제거해야 함 = release
-                .handleAsync((unused, throwable) -> {
-                    releaseDraw(key);
-                    if(throwable != null) log.error(throwable.getMessage(), throwable);
-                    return null;
-                });
+        // 예외가 발생하더라도 추첨이 끝나면 키를 제거해야 함 = release
+        .handleAsync((unused, throwable) -> {
+            releaseDraw(key);
+            if(throwable != null) log.error(throwable.getMessage(), throwable);
+            return null;
+        });
     }
 
     private void tryDraw(String key) {
@@ -65,7 +65,7 @@ public class DrawEventService {
         redisTemplate.delete(key);
     }
 
-    protected void validateDrawCondition(EventMetadata event, LocalDateTime now) {
+    private void validateDrawCondition(EventMetadata event, LocalDateTime now) {
         // 이벤트가 draw event 인지 검사
         if (event.getEventType() != EventType.draw) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
         // 이벤트가 종료되었는지 검사

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -1,26 +1,22 @@
 package hyundai.softeer.orange.event.draw.service;
 
 import hyundai.softeer.orange.common.ErrorCode;
-import hyundai.softeer.orange.event.draw.component.picker.PickTarget;
-import hyundai.softeer.orange.event.draw.component.score.ScoreCalculator;
-import hyundai.softeer.orange.event.draw.dto.DrawEventWinningInfoBulkInsertDto;
+import hyundai.softeer.orange.event.common.EventConst;
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.common.exception.EventException;
+import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
-import hyundai.softeer.orange.event.draw.entity.DrawEventMetadata;
-import hyundai.softeer.orange.event.draw.entity.DrawEventScorePolicy;
 import hyundai.softeer.orange.event.draw.exception.DrawEventException;
-import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
-import hyundai.softeer.orange.event.draw.component.picker.WinnerPicker;
-import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 /**
  * 추첨 이벤트를 다루는 서비스
@@ -29,72 +25,56 @@ import java.util.List;
 @Service
 public class DrawEventService {
     private static final Logger log = LoggerFactory.getLogger(DrawEventService.class);
-    private final DrawEventRepository deRepository;
-    private final DrawEventWinningInfoRepository deWinningInfoRepository;
-    private final WinnerPicker picker;
-    private final ScoreCalculator calculator;
+    private final EventMetadataRepository emRepository;
+    private final DrawEventDrawMachine machine;
+    private final StringRedisTemplate redisTemplate;
 
     /**
      * eventId에 대한 추첨을 진행하는 메서드
      * @param drawEventId draw event의 id 값.
      */
     @Transactional
-    @Async
-    public void draw(Long drawEventId) {
-        // 채점 & 추첨 과정 분리하는 것도 좋을것 같다.
-        DrawEvent drawEvent = deRepository.findById(drawEventId)
-                .orElseThrow(() -> new DrawEventException(ErrorCode.DRAW_EVENT_NOT_FOUND));
+    public void draw(String drawEventId) {
+        // 이벤트가 존재하는지 검사
+        EventMetadata event = emRepository.findFirstByEventId(drawEventId)
+                .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        DrawEvent drawEvent = event.getDrawEvent(); // draw event fetch
+        // 이벤트 검증
+        validateDrawCondition(event, LocalDateTime.now());
+        String key = EventConst.IS_DRAWING(event.getEventId());
+        tryDraw(key);
 
-        // draw event의 primary key id 값
-        long drawEventRawId = drawEvent.getId();
+        machine.draw(drawEvent)
+                // 예외가 발생하더라도 추첨이 끝나면 키를 제거해야 함 = release
+                .handleAsync((unused, throwable) -> {
+                    releaseDraw(key);
+                    if(throwable != null) log.error(throwable.getMessage(), throwable);
+                    return null;
+                });
+    }
 
-        // 점수 계산. 추후 추첨 과정과 분리될 수도 있음.
-        List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();
-        var userScoreMap = calculator.calculate(drawEventRawId, policies);
+    private void tryDraw(String key) {
+        Long count = redisTemplate.opsForValue().increment(key);
+        assert count != null; // 트랜잭션이 아니므로 null 이면 안됨.
+        if (count > 1) throw new DrawEventException(ErrorCode.EVENT_IS_DRAWING);
+        // N 시간동안 유지. 추후 변경될 수 있음
+        redisTemplate.expire(key, Duration.ofHours(24));
+    }
 
-        // 추첨 타겟 리스트 생성
-        List<PickTarget> targets = userScoreMap.entrySet().stream()
-                .map(it -> new PickTarget(it.getKey(), it.getValue())).toList();
+    private void releaseDraw(String key) {
+        redisTemplate.delete(key);
+    }
 
-        // 몇 등이 몇명이나 있는지 적혀 있는 정보. 등급끼리 정렬해서 1 ~ n 등 순서로 정렬
-        // 확률 높은 사람이 손해보면 안됨
-        List<DrawEventMetadata> metadataList = drawEvent.getMetadataList();
-        metadataList.sort(Comparator.comparing(DrawEventMetadata::getGrade));
+    protected void validateDrawCondition(EventMetadata event, LocalDateTime now) {
+        // 이벤트가 draw event 인지 검사
+        if (event.getEventType() != EventType.draw) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
+        // 이벤트가 종료되었는지 검사
+        if (now.isBefore(event.getEndTime())) throw new DrawEventException(ErrorCode.EVENT_NOT_ENDED);
 
-        // 총 당첨 인원 설정
-        long pickCount = metadataList.stream()
-                .mapToLong(DrawEventMetadata::getCount).sum();
-
-        // 당첨된 인원 구하기
-        var pickedTargets = picker.pick(targets, pickCount);
-
-        // 이하 영역은 여러 작업을 동시에 수행할 수도 있음
-        // ex) 인원 등록 / 상품 문자 발송 ...
-
-        // 인원 등록을 위한 작업
-        List<DrawEventWinningInfoBulkInsertDto> insertTargets = new ArrayList<>();
-        int mdIdx = -1;
-        long remain = 0;
-        long grade = -1;
-        DrawEventMetadata metadata = null;
-
-        for(var target : pickedTargets) {
-            if(remain <= 0) {
-                mdIdx++;
-                metadata = metadataList.get(mdIdx);
-                grade = metadata.getGrade();
-                remain = metadata.getCount();
-            }
-
-            insertTargets.add(DrawEventWinningInfoBulkInsertDto.of(
-                    target.key(),
-                    grade,
-                    drawEventRawId
-            ));
-            remain--;
-        }
-
-        log.info("Draw Event: {}, Winners: {}", drawEventRawId, insertTargets.size());
-        deWinningInfoRepository.insertMany(insertTargets);
+        // draw 이벤트 객체가 있는지 검사
+        DrawEvent drawEvent = event.getDrawEvent();
+        if (drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
+        // 이벤트가 이미 추첨되었는지 검사
+        if (drawEvent.isDrawn()) throw new DrawEventException(ErrorCode.ALREADY_DRAWN);
     }
 }

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachineTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachineTest.java
@@ -1,0 +1,85 @@
+package hyundai.softeer.orange.event.draw.service;
+
+import hyundai.softeer.orange.event.draw.component.picker.PickTarget;
+import hyundai.softeer.orange.event.draw.component.picker.WinnerPicker;
+import hyundai.softeer.orange.event.draw.component.score.ScoreCalculator;
+import hyundai.softeer.orange.event.draw.dto.DrawEventWinningInfoBulkInsertDto;
+import hyundai.softeer.orange.event.draw.entity.DrawEvent;
+import hyundai.softeer.orange.event.draw.entity.DrawEventMetadata;
+import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
+import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class DrawEventDrawMachineTest {
+
+    @DisplayName("대응되는 이벤트가 존재하면 작업 수행")
+    @Test
+    void drawEvent() {
+        // draw event 처리
+        var drawEvent = mock(DrawEvent.class);
+
+        // 정확한 인원 수를 추첨하는지
+        when(drawEvent.getMetadataList()).thenReturn(new ArrayList<>(List.of(
+                // 합 = 5
+                DrawEventMetadata.of(3L, 2L, null, null),
+                DrawEventMetadata.of(1L, 1L, null, null),
+                DrawEventMetadata.of(2L, 2L, null, null)
+        )));
+        when(drawEvent.getPolicyList()).thenReturn(List.of());
+
+        var deRepository = mock(DrawEventRepository.class);
+        when(deRepository.findById(anyLong())).thenReturn(Optional.of(drawEvent));
+
+        // repository 모킹. saveMany 호출하는지 검사 필요
+        var deWinningInfoRepository = mock(DrawEventWinningInfoRepository.class);
+
+        // 점수 채점기 모킹
+        var calculator = mock(ScoreCalculator.class);
+        when(calculator.calculate(anyLong(), anyList())).thenReturn(Map.of(1L, 1L, 2L, 10L, 3L,5L));
+
+        // 추첨기 모킹
+        var picker = mock(WinnerPicker.class);
+        when(picker.pick(anyList(), anyLong())).thenReturn(new ArrayList<>(
+                List.of(
+                        new PickTarget(2L, 1L), // 1
+                        new PickTarget(1L, 2L), // 2
+                        new PickTarget(3L, 3L), // 2
+                        new PickTarget(5L, 1L), // 3
+                        new PickTarget(4L, 2L) // 3
+                )));
+
+        var drawEventMachine = new DrawEventDrawMachine(deWinningInfoRepository, deRepository, picker, calculator);
+        drawEventMachine.draw(drawEvent);
+
+        ArgumentCaptor<List<DrawEventWinningInfoBulkInsertDto>> ac = ArgumentCaptor.forClass(List.class);
+
+        verify(picker, times(1)).pick(anyList(), eq(5L));
+        verify(deWinningInfoRepository, times(1)).insertMany(ac.capture());
+
+        var list = ac.getValue();
+        assertThat(list).hasSize(5);
+        assertThat(list.get(0).getEventUserId()).isEqualTo(2L);
+        assertThat(list.get(1).getEventUserId()).isEqualTo(1L);
+        assertThat(list.get(2).getEventUserId()).isEqualTo(3L);
+        assertThat(list.get(3).getEventUserId()).isEqualTo(5L);
+        assertThat(list.get(4).getEventUserId()).isEqualTo(4L);
+
+        assertThat(list.get(0).getRanking()).isEqualTo(1L);
+        assertThat(list.get(1).getRanking()).isEqualTo(2L);
+        assertThat(list.get(2).getRanking()).isEqualTo(2L);
+        assertThat(list.get(3).getRanking()).isEqualTo(3L);
+        assertThat(list.get(4).getRanking()).isEqualTo(3L);
+    }
+}

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -1,23 +1,33 @@
 package hyundai.softeer.orange.event.draw.service;
 
+import hyundai.softeer.orange.event.common.EventConst;
+import hyundai.softeer.orange.event.common.entity.EventMetadata;
+import hyundai.softeer.orange.event.common.enums.EventType;
+import hyundai.softeer.orange.event.common.exception.EventException;
+import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.draw.component.picker.PickTarget;
 import hyundai.softeer.orange.event.draw.component.picker.WinnerPicker;
 import hyundai.softeer.orange.event.draw.component.score.ScoreCalculator;
 import hyundai.softeer.orange.event.draw.dto.DrawEventWinningInfoBulkInsertDto;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import hyundai.softeer.orange.event.draw.entity.DrawEventMetadata;
+import hyundai.softeer.orange.event.draw.exception.DrawEventException;
 import hyundai.softeer.orange.event.draw.repository.DrawEventRepository;
 import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,81 +36,156 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 class DrawEventServiceTest {
+    EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
+    DrawEventDrawMachine machine = mock(DrawEventDrawMachine.class);
+    StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
 
-//    private static final Logger log = LoggerFactory.getLogger(DrawEventServiceTest.class);
-//
-//    @DisplayName("대응되는 이벤트가 존재하지 않으면 예외 반환")
-//    @Test
-//    void throwExceptionIfDrawEventNotFound() {
-//        var deRepository = mock(DrawEventRepository.class);
-//        when(deRepository.findById(anyLong())).thenReturn(Optional.empty());
-//
-//        var deService = new DrawEventService(deRepository, null, null, null);
-//
-//        assertThatThrownBy(() -> {
-//            deService.draw(0L);
-//        });
-//    }
-//
-//    @DisplayName("대응되는 이벤트가 존재하면 작업 수행")
-//    @Test
-//    void drawEvent() {
-//        // draw event 처리
-//        var drawEvent = mock(DrawEvent.class);
-//
-//        // 정확한 인원 수를 추첨하는지
-//        when(drawEvent.getMetadataList()).thenReturn(new ArrayList<>(List.of(
-//                // 합 = 5
-//                DrawEventMetadata.of(3L, 2L, null, null),
-//                DrawEventMetadata.of(1L, 1L, null, null),
-//                DrawEventMetadata.of(2L, 2L, null, null)
-//        )));
-//        when(drawEvent.getPolicyList()).thenReturn(List.of());
-//
-//        var deRepository = mock(DrawEventRepository.class);
-//        when(deRepository.findById(anyLong())).thenReturn(Optional.of(drawEvent));
-//
-//        // repository 모킹. saveMany 호출하는지 검사 필요
-//        var deWinningInfoRepository = mock(DrawEventWinningInfoRepository.class);
-//
-//        // 점수 채점기 모킹
-//        var calculator = mock(ScoreCalculator.class);
-//        when(calculator.calculate(anyLong(), anyList())).thenReturn(Map.of(1L, 1L, 2L, 10L, 3L,5L));
-//
-//        // 추첨기 모킹
-//        var picker = mock(WinnerPicker.class);
-//        when(picker.pick(anyList(), anyLong())).thenReturn(new ArrayList<>(
-//                List.of(
-//                new PickTarget(2L, 1L), // 1
-//                new PickTarget(1L, 2L), // 2
-//                new PickTarget(3L, 3L), // 2
-//                new PickTarget(5L, 1L), // 3
-//                new PickTarget(4L, 2L) // 3
-//        )));
-//
-//        var deService = new DrawEventService(deRepository, deWinningInfoRepository, picker, calculator);
-//
-//        deService.draw(0L);
-//
-//        ArgumentCaptor<List<DrawEventWinningInfoBulkInsertDto>> ac = ArgumentCaptor.forClass(List.class);
-//
-//        verify(picker, times(1)).pick(anyList(), eq(5L));
-//        verify(deWinningInfoRepository, times(1)).insertMany(ac.capture());
-//
-//        var list = ac.getValue();
-//        assertThat(list).hasSize(5);
-//        assertThat(list.get(0).getEventUserId()).isEqualTo(2L);
-//        assertThat(list.get(1).getEventUserId()).isEqualTo(1L);
-//        assertThat(list.get(2).getEventUserId()).isEqualTo(3L);
-//        assertThat(list.get(3).getEventUserId()).isEqualTo(5L);
-//        assertThat(list.get(4).getEventUserId()).isEqualTo(4L);
-//        for(var v: list) {
-//            log.info("ranking {}", v.getRanking());
-//        }
-//        assertThat(list.get(0).getRanking()).isEqualTo(1L);
-//        assertThat(list.get(1).getRanking()).isEqualTo(2L);
-//        assertThat(list.get(2).getRanking()).isEqualTo(2L);
-//        assertThat(list.get(3).getRanking()).isEqualTo(3L);
-//        assertThat(list.get(4).getRanking()).isEqualTo(3L);
-//    }
+    @AfterEach
+    void afterEach() {
+        reset(emRepository,machine,redisTemplate);
+    }
+
+    @DisplayName("대응되는 이벤트가 존재하지 않으면 예외 반환")
+    @Test
+    void draw_throwIfDrawEventNotFound() {
+        String eventId = "test-key";
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.empty());
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+    }
+
+    @DisplayName("추첨 이벤트가 아니면 예외 반환")
+    @Test
+    void draw_throwIfNotDrawType() {
+        String eventId = "test-key";
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.fcfs)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+    }
+
+
+    @DisplayName("이벤트가 종료되지 않았다면 예외 반환")
+    @Test
+    void draw_throwIfEventNotEnded() {
+        String eventId = "test-key";
+        var endTime = LocalDateTime.now().plusDays(10);
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.draw)
+                .endTime(endTime)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+    }
+
+
+    @DisplayName("추첨 이벤트를 가져올 수 없다면 예외 반환")
+    @Test
+    void draw_throwIfDrawEventIsNull() {
+        String eventId = "test-key";
+        var endTime = LocalDateTime.now().plusDays(-10);
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.draw)
+                .endTime(endTime)
+                .drawEvent(null)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+    }
+
+    @DisplayName("추첨 이벤트가 이미 추첨된 상태라면 예외 반환")
+    @Test
+    void draw_throwIfDrawEventIsAlreadyDrawn() {
+        String eventId = "test-key";
+        var endTime = LocalDateTime.now().plusDays(-10);
+        var drawEvent = new DrawEvent();
+        drawEvent.setDrawn(true);
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.draw)
+                .endTime(endTime)
+                .drawEvent(drawEvent)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+    }
+
+    @DisplayName("이벤트가 현재 추첨 중이라면 예외 반환")
+    @Test
+    void draw_throwIfDrawEventIsDrawing() {
+        String eventId = "test-key";
+        String key = EventConst.IS_DRAWING(eventId);
+        var endTime = LocalDateTime.now().plusDays(-10);
+        var drawEvent = new DrawEvent();
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.draw)
+                .endTime(endTime)
+                .drawEvent(drawEvent)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+        ValueOperations<String, String> ops = mock(ValueOperations.class);
+        // 현재 진입 중인 사람이 있음
+        when(ops.increment(key)).thenReturn(2L);
+        when(redisTemplate.opsForValue()).thenReturn(ops);
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+
+        assertThatThrownBy(() -> {
+            deService.draw(eventId);
+        });
+        verify(ops, times(1)).increment(key);
+        verify(redisTemplate, times(1)).opsForValue();
+    }
+
+    @DisplayName("이벤트 추첨 조건이 된다면 추첨 진행")
+    @Test
+    void draw_successfullyDraw() {
+        String eventId = "test-key";
+        String key = EventConst.IS_DRAWING(eventId);
+        var endTime = LocalDateTime.now().plusDays(-10);
+        var drawEvent = new DrawEvent();
+        var eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .eventType(EventType.draw)
+                .endTime(endTime)
+                .drawEvent(drawEvent)
+                .build();
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+        ValueOperations<String, String> ops = mock(ValueOperations.class);
+        when(ops.increment(key)).thenReturn(1L);
+        when(redisTemplate.opsForValue()).thenReturn(ops);
+        when(machine.draw(any(DrawEvent.class))).thenReturn(CompletableFuture.completedFuture(null));
+
+        var deService = new DrawEventService(emRepository, machine, redisTemplate);
+        deService.draw("test-key");
+
+        verify(ops, times(1)).increment(key);
+        verify(redisTemplate, times(1)).delete(key);
+        verify(redisTemplate, times(1)).opsForValue();
+        verify(machine, times(1)).draw(any(DrawEvent.class));
+    }
 }

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -163,7 +164,7 @@ class DrawEventServiceTest {
 
     @DisplayName("이벤트 추첨 조건이 된다면 추첨 진행")
     @Test
-    void draw_successfullyDraw() {
+    void draw_successfullyDraw() throws InterruptedException {
         String eventId = "test-key";
         String key = EventConst.IS_DRAWING(eventId);
         var endTime = LocalDateTime.now().plusDays(-10);
@@ -184,6 +185,7 @@ class DrawEventServiceTest {
         var deService = new DrawEventService(emRepository, machine, redisTemplate);
         deService.draw("test-key");
         future.join(); // 비동기 끝날 때까지 대기 -> delete 실행되는지 검사
+        TimeUnit.SECONDS.sleep(1L);
 
         verify(ops, times(1)).increment(key);
         verify(redisTemplate, times(1)).delete(key);

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -178,10 +178,12 @@ class DrawEventServiceTest {
         ValueOperations<String, String> ops = mock(ValueOperations.class);
         when(ops.increment(key)).thenReturn(1L);
         when(redisTemplate.opsForValue()).thenReturn(ops);
-        when(machine.draw(any(DrawEvent.class))).thenReturn(CompletableFuture.completedFuture(null));
+        CompletableFuture<Void> future = CompletableFuture.completedFuture(null);
+        when(machine.draw(any(DrawEvent.class))).thenReturn(future);
 
         var deService = new DrawEventService(emRepository, machine, redisTemplate);
         deService.draw("test-key");
+        future.join(); // 비동기 끝날 때까지 대기 -> delete 실행되는지 검사
 
         verify(ops, times(1)).increment(key);
         verify(redisTemplate, times(1)).delete(key);

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -27,80 +27,80 @@ import static org.mockito.Mockito.*;
 
 class DrawEventServiceTest {
 
-    private static final Logger log = LoggerFactory.getLogger(DrawEventServiceTest.class);
-
-    @DisplayName("대응되는 이벤트가 존재하지 않으면 예외 반환")
-    @Test
-    void throwExceptionIfDrawEventNotFound() {
-        var deRepository = mock(DrawEventRepository.class);
-        when(deRepository.findById(anyLong())).thenReturn(Optional.empty());
-
-        var deService = new DrawEventService(deRepository, null, null, null);
-
-        assertThatThrownBy(() -> {
-            deService.draw(0L);
-        });
-    }
-
-    @DisplayName("대응되는 이벤트가 존재하면 작업 수행")
-    @Test
-    void drawEvent() {
-        // draw event 처리
-        var drawEvent = mock(DrawEvent.class);
-
-        // 정확한 인원 수를 추첨하는지
-        when(drawEvent.getMetadataList()).thenReturn(new ArrayList<>(List.of(
-                // 합 = 5
-                DrawEventMetadata.of(3L, 2L, null, null),
-                DrawEventMetadata.of(1L, 1L, null, null),
-                DrawEventMetadata.of(2L, 2L, null, null)
-        )));
-        when(drawEvent.getPolicyList()).thenReturn(List.of());
-
-        var deRepository = mock(DrawEventRepository.class);
-        when(deRepository.findById(anyLong())).thenReturn(Optional.of(drawEvent));
-
-        // repository 모킹. saveMany 호출하는지 검사 필요
-        var deWinningInfoRepository = mock(DrawEventWinningInfoRepository.class);
-
-        // 점수 채점기 모킹
-        var calculator = mock(ScoreCalculator.class);
-        when(calculator.calculate(anyLong(), anyList())).thenReturn(Map.of(1L, 1L, 2L, 10L, 3L,5L));
-
-        // 추첨기 모킹
-        var picker = mock(WinnerPicker.class);
-        when(picker.pick(anyList(), anyLong())).thenReturn(new ArrayList<>(
-                List.of(
-                new PickTarget(2L, 1L), // 1
-                new PickTarget(1L, 2L), // 2
-                new PickTarget(3L, 3L), // 2
-                new PickTarget(5L, 1L), // 3
-                new PickTarget(4L, 2L) // 3
-        )));
-
-        var deService = new DrawEventService(deRepository, deWinningInfoRepository, picker, calculator);
-
-        deService.draw(0L);
-
-        ArgumentCaptor<List<DrawEventWinningInfoBulkInsertDto>> ac = ArgumentCaptor.forClass(List.class);
-
-        verify(picker, times(1)).pick(anyList(), eq(5L));
-        verify(deWinningInfoRepository, times(1)).insertMany(ac.capture());
-
-        var list = ac.getValue();
-        assertThat(list).hasSize(5);
-        assertThat(list.get(0).getEventUserId()).isEqualTo(2L);
-        assertThat(list.get(1).getEventUserId()).isEqualTo(1L);
-        assertThat(list.get(2).getEventUserId()).isEqualTo(3L);
-        assertThat(list.get(3).getEventUserId()).isEqualTo(5L);
-        assertThat(list.get(4).getEventUserId()).isEqualTo(4L);
-        for(var v: list) {
-            log.info("ranking {}", v.getRanking());
-        }
-        assertThat(list.get(0).getRanking()).isEqualTo(1L);
-        assertThat(list.get(1).getRanking()).isEqualTo(2L);
-        assertThat(list.get(2).getRanking()).isEqualTo(2L);
-        assertThat(list.get(3).getRanking()).isEqualTo(3L);
-        assertThat(list.get(4).getRanking()).isEqualTo(3L);
-    }
+//    private static final Logger log = LoggerFactory.getLogger(DrawEventServiceTest.class);
+//
+//    @DisplayName("대응되는 이벤트가 존재하지 않으면 예외 반환")
+//    @Test
+//    void throwExceptionIfDrawEventNotFound() {
+//        var deRepository = mock(DrawEventRepository.class);
+//        when(deRepository.findById(anyLong())).thenReturn(Optional.empty());
+//
+//        var deService = new DrawEventService(deRepository, null, null, null);
+//
+//        assertThatThrownBy(() -> {
+//            deService.draw(0L);
+//        });
+//    }
+//
+//    @DisplayName("대응되는 이벤트가 존재하면 작업 수행")
+//    @Test
+//    void drawEvent() {
+//        // draw event 처리
+//        var drawEvent = mock(DrawEvent.class);
+//
+//        // 정확한 인원 수를 추첨하는지
+//        when(drawEvent.getMetadataList()).thenReturn(new ArrayList<>(List.of(
+//                // 합 = 5
+//                DrawEventMetadata.of(3L, 2L, null, null),
+//                DrawEventMetadata.of(1L, 1L, null, null),
+//                DrawEventMetadata.of(2L, 2L, null, null)
+//        )));
+//        when(drawEvent.getPolicyList()).thenReturn(List.of());
+//
+//        var deRepository = mock(DrawEventRepository.class);
+//        when(deRepository.findById(anyLong())).thenReturn(Optional.of(drawEvent));
+//
+//        // repository 모킹. saveMany 호출하는지 검사 필요
+//        var deWinningInfoRepository = mock(DrawEventWinningInfoRepository.class);
+//
+//        // 점수 채점기 모킹
+//        var calculator = mock(ScoreCalculator.class);
+//        when(calculator.calculate(anyLong(), anyList())).thenReturn(Map.of(1L, 1L, 2L, 10L, 3L,5L));
+//
+//        // 추첨기 모킹
+//        var picker = mock(WinnerPicker.class);
+//        when(picker.pick(anyList(), anyLong())).thenReturn(new ArrayList<>(
+//                List.of(
+//                new PickTarget(2L, 1L), // 1
+//                new PickTarget(1L, 2L), // 2
+//                new PickTarget(3L, 3L), // 2
+//                new PickTarget(5L, 1L), // 3
+//                new PickTarget(4L, 2L) // 3
+//        )));
+//
+//        var deService = new DrawEventService(deRepository, deWinningInfoRepository, picker, calculator);
+//
+//        deService.draw(0L);
+//
+//        ArgumentCaptor<List<DrawEventWinningInfoBulkInsertDto>> ac = ArgumentCaptor.forClass(List.class);
+//
+//        verify(picker, times(1)).pick(anyList(), eq(5L));
+//        verify(deWinningInfoRepository, times(1)).insertMany(ac.capture());
+//
+//        var list = ac.getValue();
+//        assertThat(list).hasSize(5);
+//        assertThat(list.get(0).getEventUserId()).isEqualTo(2L);
+//        assertThat(list.get(1).getEventUserId()).isEqualTo(1L);
+//        assertThat(list.get(2).getEventUserId()).isEqualTo(3L);
+//        assertThat(list.get(3).getEventUserId()).isEqualTo(5L);
+//        assertThat(list.get(4).getEventUserId()).isEqualTo(4L);
+//        for(var v: list) {
+//            log.info("ranking {}", v.getRanking());
+//        }
+//        assertThat(list.get(0).getRanking()).isEqualTo(1L);
+//        assertThat(list.get(1).getRanking()).isEqualTo(2L);
+//        assertThat(list.get(2).getRanking()).isEqualTo(2L);
+//        assertThat(list.get(3).getRanking()).isEqualTo(3L);
+//        assertThat(list.get(4).getRanking()).isEqualTo(3L);
+//    }
 }

--- a/src/test/resources/sql/CustomDrawEventWinningInfoRepositoryImplTest.sql
+++ b/src/test/resources/sql/CustomDrawEventWinningInfoRepositoryImplTest.sql
@@ -3,14 +3,14 @@ INSERT INTO event_frame(frame_id, name) VALUES ('frame_id1', 'test');
 INSERT INTO event_metadata(event_type, event_frame_id, event_id)
 VALUES (1, 1, 'HD_240808_001');
 
-INSERT INTO draw_event(event_metadata_id)
-VALUES (1);
+INSERT INTO draw_event(event_metadata_id, is_drawn)
+VALUES (1, 0);
 
 INSERT INTO event_metadata(event_type, event_frame_id, event_id)
 VALUES (1, 1, 'HD_240808_002');
 
-INSERT INTO draw_event(event_metadata_id)
-VALUES (2);
+INSERT INTO draw_event(event_metadata_id, is_drawn)
+VALUES (2, 0);
 
 INSERT INTO event_user(score, event_frame_id, user_id)
 VALUES (0, 1, 'user1');

--- a/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
+++ b/src/test/resources/sql/EventParticipationInfoRepositoryTest.sql
@@ -6,7 +6,7 @@ INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 1, '
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 2, 'HD_240808_002');
 INSERT INTO event_metadata(event_type, event_frame_id, event_id) VALUES (1, 3, 'HD_240808_003');
 
-INSERT INTO draw_event(event_metadata_id) VALUES(1);
+INSERT INTO draw_event(event_metadata_id, is_drawn) VALUES(1, 0);
 
 INSERT INTO event_user(score, event_frame_id, user_id) VALUES (0, 1, 'user1');
 INSERT INTO event_user(score, event_frame_id, user_id) VALUES (0, 1, 'user2');


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #67

# 📝 작업 내용

 - [x] 이벤트 추첨 중 재추첨 불가능하도록 방지
 - [x] 이미 추첨 된 이벤트를 재추첨할 수 없도록 방지
 - [x] 추첨 로직 api와 연결

추첨 작업은 시간이 오래 걸릴 수 있습니다. 이때, 추첨 작업이 진행되는 동안 사용자가 응답을 대기해야 한다면 매우 불편할 수 있습니다. 사용자가 추첨 버튼을 클릭한 이후 대기하지 않기 위해서는 작업을 비동기적으로 처리해야 합니다.

위 요구조건을 달성하기 위해 CompletableFuture, Async 어노테이션을 이용, 작업을 비동기적으로 처리할 수 있도록 구성했습니다.