### PR TITLE
[test] 통합테스트 @DirtiesContext 제거하여 테스트 속도 개선 (#71)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -32,4 +32,6 @@ jobs:
         run: sudo docker rm -f orange || true
 
       - name: Run Updated Docker Container
-        run: sudo docker run -t --env-file ~/.env -d --name orange -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/orange
+        run: sudo docker run -t -d --name orange -p 8080:8080 \
+          --env SERVER_SECRET=$(aws ssm get-parameter --name ${{ secrets.SSM_PARAMETER_NAME }} --with-decryption --region ${{ secrets.SSM_PARAMETER_REGION }} --query "Parameter.Value" --output text) \
+          ${{ secrets.DOCKERHUB_USERNAME }}/orange

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Test with Gradle
-        run: ./gradlew clean test --no-build-cache -Dspring.profiles.active=test
+        run: ./gradlew test
 
       - name: Build with Gradle
         run: ./gradlew build -x test

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
     <!-- 기본 환경 설정 -->
-    <springProfile name="default">
+    <springProfile name="!test">
         <property name="LOG_DIR" value="/var/log/spring-boot" />
 
         <!-- 콘솔 출력 설정 -->

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <configuration>
     <!-- 기본 환경 설정 -->
-    <springProfile name="!test">
+    <springProfile name="default">
         <property name="LOG_DIR" value="/var/log/spring-boot" />
 
         <!-- 콘솔 출력 설정 -->

--- a/src/test/java/hyundai/softeer/orange/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/repository/CommentRepositoryTest.java
@@ -1,11 +1,10 @@
 package hyundai.softeer.orange.comment.repository;
 
 import hyundai.softeer.orange.comment.dto.WriteCommentCountDto;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -13,9 +12,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql(value = "classpath:sql/CommentRepositoryTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class CommentRepositoryTest {
+class CommentRepositoryTest extends IntegrationDataJpaTest {
     @Autowired
     CommentRepository commentRepository;
 

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapperTest.java
@@ -8,7 +8,7 @@ import hyundai.softeer.orange.event.dto.EventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventMetadataDto;
 import hyundai.softeer.orange.event.dto.draw.DrawEventScorePolicyDto;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,8 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@TCDataJpaTest
-class DrawEventFieldMapperTest {
+class DrawEventFieldMapperTest extends IntegrationDataJpaTest {
     @Autowired
     DrawEventMetadataRepository drawEventMetadataRepository;
     @Autowired

--- a/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/repository/EventSpecificationTest.java
@@ -2,22 +2,19 @@ package hyundai.softeer.orange.event.common.repository;
 
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class EventSpecificationTest {
+class EventSpecificationTest extends IntegrationDataJpaTest {
     @Autowired
     EventFrameRepository efRepository;
     @Autowired
@@ -52,7 +49,7 @@ class EventSpecificationTest {
         Specification<EventMetadata> spec = EventSpecification.searchOnName(null);
         Specification<EventMetadata> spec2 = EventSpecification.searchOnEventId(null);
 
-        Page<EventMetadata> result = emRepository.findAll(spec.or(spec2), PageRequest.of(0,100));
+        Page<EventMetadata> result = emRepository.findAll(spec.or(spec2), PageRequest.of(0, 100));
         assertThat(result.getTotalElements()).isEqualTo(3);
     }
 
@@ -60,7 +57,7 @@ class EventSpecificationTest {
     @Test
     void searchWithSearchClause() {
         String search = "event";
-        EventFrame ef = EventFrame.of("the-new-ioniq5","test");
+        EventFrame ef = EventFrame.of("the-new-ioniq5", "test");
         efRepository.save(ef);
         // event 포함 ( name )
         EventMetadata em1 = EventMetadata.builder()
@@ -94,7 +91,7 @@ class EventSpecificationTest {
         Specification<EventMetadata> spec1 = EventSpecification.searchOnName(search);
         Specification<EventMetadata> spec2 = EventSpecification.searchOnEventId(search);
 
-        Page<EventMetadata> result = emRepository.findAll(spec1.or(spec2), PageRequest.of(0,100));
+        Page<EventMetadata> result = emRepository.findAll(spec1.or(spec2), PageRequest.of(0, 100));
 
         assertThat(result.getTotalElements()).isEqualTo(3);
     }

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -7,12 +7,11 @@ import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
 import hyundai.softeer.orange.event.dto.BriefEventDto;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,9 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class EventServiceSearchEventsTest {
+class EventServiceSearchEventsTest extends IntegrationDataJpaTest {
     @Autowired
     private EventMetadataRepository emRepo;
     @Autowired

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
@@ -7,12 +7,11 @@ import hyundai.softeer.orange.event.common.enums.EventType;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.component.EventKeyGenerator;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,9 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class EventServiceSearchHintsTest  {
+class EventServiceSearchHintsTest extends IntegrationDataJpaTest {
     @Autowired
     private EventMetadataRepository emRepo;
     @Autowired

--- a/src/test/java/hyundai/softeer/orange/event/draw/repository/CustomDrawEventWinningInfoRepositoryImplTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/repository/CustomDrawEventWinningInfoRepositoryImplTest.java
@@ -1,11 +1,10 @@
 package hyundai.softeer.orange.event.draw.repository;
 
 import hyundai.softeer.orange.event.draw.dto.DrawEventWinningInfoBulkInsertDto;
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -13,9 +12,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql(value="classpath:sql/CustomDrawEventWinningInfoRepositoryImplTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class CustomDrawEventWinningInfoRepositoryImplTest {
+class CustomDrawEventWinningInfoRepositoryImplTest extends IntegrationDataJpaTest {
     @Autowired // DrawEventWinningInfoRepository로 접근 가능해야 함
     private DrawEventWinningInfoRepository repo;
 

--- a/src/test/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepositoryTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepositoryTest.java
@@ -1,17 +1,14 @@
 package hyundai.softeer.orange.event.draw.repository;
 
-import hyundai.softeer.orange.support.TCDataJpaTest;
+import hyundai.softeer.orange.support.IntegrationDataJpaTest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql(value = "classpath:sql/EventParticipationInfoRepositoryTest.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
-@TCDataJpaTest
-class EventParticipationInfoRepositoryTest {
+class EventParticipationInfoRepositoryTest extends IntegrationDataJpaTest {
     @Autowired
     EventParticipationInfoRepository epiRepository;
 

--- a/src/test/java/hyundai/softeer/orange/support/IntegrationDataJpaTest.java
+++ b/src/test/java/hyundai/softeer/orange/support/IntegrationDataJpaTest.java
@@ -13,13 +13,9 @@ public abstract class IntegrationDataJpaTest {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    // 이 클래스를 상속받는 모든 테스트 클래스는 모든 테스트가 끝나면 모든 테이블의 데이터를 삭제한다.
+    // 이 클래스를 상속받는 모든 통합 테스트 클래스는 테스트가 끝나면 모든 테이블의 데이터를 삭제한다.
     @AfterAll
-    void tearDownAll() {
-        clear();
-    }
-
-    private void clear(){
+    void clearDatabase(){
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
         List<String> tableNameList = jdbcTemplate.queryForList("SHOW TABLES", String.class); // 모든 테이블 이름을 가져온다.
         for(String tableName : tableNameList) {

--- a/src/test/java/hyundai/softeer/orange/support/IntegrationDataJpaTest.java
+++ b/src/test/java/hyundai/softeer/orange/support/IntegrationDataJpaTest.java
@@ -1,0 +1,31 @@
+package hyundai.softeer.orange.support;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+
+@TCDataJpaTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class IntegrationDataJpaTest {
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    // 이 클래스를 상속받는 모든 테스트 클래스는 모든 테스트가 끝나면 모든 테이블의 데이터를 삭제한다.
+    @AfterAll
+    void tearDownAll() {
+        clear();
+    }
+
+    private void clear(){
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+        List<String> tableNameList = jdbcTemplate.queryForList("SHOW TABLES", String.class); // 모든 테이블 이름을 가져온다.
+        for(String tableName : tableNameList) {
+            jdbcTemplate.execute("TRUNCATE TABLE " + tableName); // 모든 테이블의 데이터를 삭제한다.
+            jdbcTemplate.execute("ALTER TABLE " + tableName + " AUTO_INCREMENT = 1"); // AUTO_INCREMENT 초기화
+        }
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #71 
- #68 

# 📝 작업 내용

> #68 에서 통합 테스트 간 데이터 일관성 문제로 지속적으로 외래키 제약 관련 에러가 발생하여, DirtiesContext를 도입하여 매 테스트 클래스마다 Context를 초기화했습니다. 이로 인해  CI에서 테스트 실행에만 3분 가까이 소요되는 문제가 있었습니다. 
>
> AfterAll 메서드를 통해 테스트 DB를 초기화하는 추상 테스트 클래스 IntegreationDataJpaTest를 통합 테스트 클래스가 상속받게 만들어, 각 테스트클래스별로 독립된 환경을 보장하면서도 CI 중 테스트에서 소모되는 시간을 1분으로 줄였습니다. 
> 
> 그 외 환경변수를 파편화해서 관리하던 문제를 해결하기 위해 CD 시 AWS Parameter Store에서 환경변수를 가져와 Docker에서 빌드할 때만 사용하도록 수정했습니다. 이제 환경변수 파일이 현재와 달리 EC2에 존재하지 않게 됩니다.

<img width="345" alt="image" src="https://github.com/user-attachments/assets/ff8be83c-f78b-4dc9-bb88-cb176638dcf6">

> 한편, logback 수정 과정에서 "default" 프로필이 의도와 달리 아예 로그를 콘솔에 출력하지 않는 버그가 있었습니다. "!test"를 통해 test 프로필이 아닌 경우 해당 설정을 반영하도록 수정했습니다. (!test가 아닌 prod만 설정하는 것도 검토해볼 만합니다.)

## 참고 이미지 및 자료
https://stackoverflow.com/questions/48714118/reset-database-after-each-test-on-spring-without-using-dirtiescontext
https://blog.gtiwari333.com/2021/07/making-integration-tests-faster-without.html#google_vignette
https://newwisdom.tistory.com/95
https://devlopsquare.tistory.com/227

# 💬 리뷰 요구사항