### PR TITLE
[feat] 관리자 댓글 검색 기능 추가(#73)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -33,10 +33,11 @@ public class AdminCommentController {
     @GetMapping
     public ResponseEntity<ResponseCommentsDto> findEventComments(
             @RequestParam String eventId,
+            @RequestParam(required=false) String search,
             @RequestParam(required = false, defaultValue = "0") Integer page,
             @RequestParam(required = false, defaultValue = "10") Integer size
     ) {
-         var comments = commentService.searchComments(eventId, page, size);
+         var comments = commentService.searchComments(eventId, search, page, size);
          return ResponseEntity.ok(comments);
     }
 

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -6,12 +6,13 @@ import hyundai.softeer.orange.comment.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, JpaSpecificationExecutor<Comment> {
 
     // DB 상에서 무작위로 추출된 n개의 긍정 기대평 목록을 조회하고 Dto로 반환, N+1 문제 방지 (JPQL)
     @Query("select new hyundai.softeer.orange.comment.dto.ResponseCommentDto(c.id, c.content, cu.userName, c.createdAt) " +

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentSpecification.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentSpecification.java
@@ -1,0 +1,25 @@
+package hyundai.softeer.orange.comment.repository;
+
+import hyundai.softeer.orange.comment.entity.Comment;
+import org.springframework.data.jpa.domain.Specification;
+
+public class CommentSpecification {
+    public static Specification<Comment> matchEventId(String eventId) {
+        return (comment, query, cb) -> cb.equal(
+
+                comment.join("eventFrame")
+                        .join("eventMetadataList")
+                        .get("eventId"), eventId);
+    }
+
+    public static Specification<Comment> searchOnContent(String search, boolean conjunctionOnNull) {
+        return (comment, query, cb) -> {
+            if (search == null || search.isEmpty()) return (conjunctionOnNull ? cb.conjunction() : cb.disjunction());
+            return cb.like(comment.get("content"), "%" + search + "%");
+        };
+    }
+
+    public static Specification<Comment> searchOnContent(String search) {
+        return searchOnContent(search, true);
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.comment.entity.Comment;
 import hyundai.softeer.orange.comment.exception.CommentException;
 import hyundai.softeer.orange.comment.repository.CommentRepository;
+import hyundai.softeer.orange.comment.repository.CommentSpecification;
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
@@ -17,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,7 +57,6 @@ public class CommentService {
 
         boolean isPositive = commentValidator.analyzeComment(dto.getContent());
 
-        // TODO: 점수정책와 연계하여 기대평 등록 시 점수를 부여 추가해야함
         Comment comment = Comment.of(dto.getContent(), eventFrame, eventUser, isPositive);
         commentRepository.save(comment);
         log.info("created comment: {}", comment.getId());
@@ -89,11 +90,16 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseCommentsDto searchComments(String eventId, Integer page, Integer size) {
+    public ResponseCommentsDto searchComments(String eventId, String search, Integer page, Integer size) {
         PageRequest pageInfo = PageRequest.of(page, size);
 
-        var comments = commentRepository.findAllByEventId(eventId,pageInfo)
-                .getContent().stream().map(ResponseCommentDto::from).toList();
+        Specification<Comment> matchEventId = CommentSpecification.matchEventId(eventId);
+        Specification<Comment> searchOnContent = CommentSpecification.searchOnContent(search);
+
+        var comments = commentRepository.findAll(
+                matchEventId.and(searchOnContent)
+        ).stream().map(ResponseCommentDto::from).toList();
+
         log.info("searched comments: {}", comments);
         return new ResponseCommentsDto(comments);
     }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -97,7 +97,8 @@ public class CommentService {
         Specification<Comment> searchOnContent = CommentSpecification.searchOnContent(search);
 
         var comments = commentRepository.findAll(
-                matchEventId.and(searchOnContent)
+                matchEventId.and(searchOnContent),
+                pageInfo
         ).stream().map(ResponseCommentDto::from).toList();
 
         log.info("searched comments: {}", comments);

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -73,11 +73,17 @@ public class EventMetadata {
     @JoinColumn(name="event_frame_id")
     private EventFrame eventFrame;
 
-    @OneToOne(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    private DrawEvent drawEvent;
+    // 원래는 one-to-one 관계이지만, JPA 동작에 의해 강제로 EAGER FETCH로 처리돰 -> one-to-many 로 관리
+    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+    private final List<DrawEvent> drawEventList = new ArrayList<>();
 
     public void updateDrawEvent(DrawEvent drawEvent) {
-        this.drawEvent = drawEvent;
+        this.drawEventList.add(drawEvent);
+    }
+
+    public DrawEvent getDrawEvent() {
+        if (drawEventList.isEmpty()) return null;
+        return drawEventList.get(0);
     }
 
     @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST, CascadeType.MERGE})

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -24,7 +24,7 @@ public class DrawEvent {
     @Column(nullable = false)
     private boolean isDrawn = false;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_metadata_id")
     private EventMetadata eventMetadata;
 

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -39,7 +39,7 @@ public class DrawEventService {
         // 이벤트가 존재하는지 검사
         EventMetadata event = emRepository.findFirstByEventId(drawEventId)
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
-        DrawEvent drawEvent = event.getDrawEvent(); // draw event fetch
+        DrawEvent drawEvent = event.getDrawEventList().get(0);
         // 이벤트 검증
         validateDrawCondition(event, LocalDateTime.now());
         String key = EventConst.IS_DRAWING(event.getEventId());

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -228,7 +228,7 @@ class CommentServiceTest {
         given(commentRepository.findAllByEventId(any(), any())).willReturn(new PageImpl<>(List.of(Comment.of("test", eventFrame, eventUser, true))));
 
         // when
-        ResponseCommentsDto dto = commentService.searchComments(eventFrameId, 0, 10);
+        ResponseCommentsDto dto = commentService.searchComments(eventFrameId, null,0, 10);
 
         // then
         assertThat(dto.getComments()).hasSize(1);

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -225,14 +226,14 @@ class CommentServiceTest {
     @Test
     void searchCommentsTest() {
         // given
-        given(commentRepository.findAllByEventId(any(), any())).willReturn(new PageImpl<>(List.of(Comment.of("test", eventFrame, eventUser, true))));
+        given(commentRepository.findAll(any(Specification.class), any(Pageable.class))).willReturn(new PageImpl<>(List.of(Comment.of("test", eventFrame, eventUser, true))));
 
         // when
-        ResponseCommentsDto dto = commentService.searchComments(eventFrameId, null,0, 10);
+        ResponseCommentsDto dto = commentService.searchComments("event-key", null,0, 10);
 
         // then
         assertThat(dto.getComments()).hasSize(1);
         assertThat(dto.getComments().get(0).getContent()).isEqualTo("test");
-        verify(commentRepository, times(1)).findAllByEventId(any(), any());
+        verify(commentRepository, times(1)).findAll(any(Specification.class), any(Pageable.class));
     }
 }

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -103,7 +103,6 @@ class DrawEventServiceTest {
                 .eventId(eventId)
                 .eventType(EventType.draw)
                 .endTime(endTime)
-                .drawEvent(null)
                 .build();
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
 
@@ -124,8 +123,8 @@ class DrawEventServiceTest {
                 .eventId(eventId)
                 .eventType(EventType.draw)
                 .endTime(endTime)
-                .drawEvent(drawEvent)
                 .build();
+        eventMetadata.updateDrawEvent(drawEvent);
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
 
         var deService = new DrawEventService(emRepository, machine, redisTemplate);
@@ -145,8 +144,8 @@ class DrawEventServiceTest {
                 .eventId(eventId)
                 .eventType(EventType.draw)
                 .endTime(endTime)
-                .drawEvent(drawEvent)
                 .build();
+        eventMetadata.updateDrawEvent(drawEvent);
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
         ValueOperations<String, String> ops = mock(ValueOperations.class);
         // 현재 진입 중인 사람이 있음
@@ -173,8 +172,8 @@ class DrawEventServiceTest {
                 .eventId(eventId)
                 .eventType(EventType.draw)
                 .endTime(endTime)
-                .drawEvent(drawEvent)
                 .build();
+        eventMetadata.updateDrawEvent(drawEvent);
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
         ValueOperations<String, String> ops = mock(ValueOperations.class);
         when(ops.increment(key)).thenReturn(1L);

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
@@ -73,13 +73,12 @@ class EventParticipationServiceTest {
     @DisplayName("정상적인 이벤트라면 참여 기록 반환")
     @Test
     void getParticipationDateList_returnParticipationInfos() {
+        var eventMetadata = EventMetadata.builder()
+                .eventType(EventType.draw)
+                .build();
+        eventMetadata.updateDrawEvent(new DrawEvent());
         EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
-        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
-                EventMetadata.builder()
-                        .eventType(EventType.draw)
-                        .drawEvent(new DrawEvent())
-                        .build()
-        ));
+        when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(eventMetadata));
         var mockDto1 = mock(EventParticipationDateDto.class);
         var mockDto2 = mock(EventParticipationDateDto.class);
         when(mockDto1.getDate()).thenReturn(LocalDateTime.now());
@@ -146,7 +145,6 @@ class EventParticipationServiceTest {
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
                 EventMetadata.builder()
                         .eventType(EventType.draw)
-                        .drawEvent(new DrawEvent())
                         .build()
         ));
         EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
@@ -167,13 +165,12 @@ class EventParticipationServiceTest {
         EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
                 EventMetadata.builder()
-                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
-                        .endTime(LocalDateTime.of(2024,8,10,0,0,0))
+                        .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
+                        .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0))
                         .eventType(EventType.draw)
-                        .drawEvent(new DrawEvent())
                         .build()
         ));
-        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+        LocalDateTime now = LocalDateTime.of(2024, 9, 1, 0, 0, 0);
 
         EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
 
@@ -185,7 +182,7 @@ class EventParticipationServiceTest {
         assertThatThrownBy(() -> {
             service.participateAtDate("test", "any", now);
         }).isInstanceOf(EventException.class);
-        verify(epiRepository, never()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+        verify(epiRepository, never()).existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any());
     }
 
     @DisplayName("오늘 참여했다면 예외 반환")
@@ -194,17 +191,16 @@ class EventParticipationServiceTest {
         EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
                 EventMetadata.builder()
-                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
-                        .endTime(LocalDateTime.of(2024,9,2,0,0,0))
+                        .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
+                        .endTime(LocalDateTime.of(2024, 9, 2, 0, 0, 0))
                         .eventType(EventType.draw)
-                        .drawEvent(new DrawEvent())
                         .build()
         ));
-        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+        LocalDateTime now = LocalDateTime.of(2024, 9, 1, 0, 0, 0);
 
         EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
         // 오늘 참여함
-        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any())).thenReturn(true);
+        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any())).thenReturn(true);
 
         EventUserRepository euRepository = mock(EventUserRepository.class);
         // 유저 있음
@@ -214,7 +210,7 @@ class EventParticipationServiceTest {
         assertThatThrownBy(() -> {
             service.participateAtDate("test", "any", now);
         }).isInstanceOf(EventException.class);
-        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any());
     }
 
     @DisplayName("오늘 처음 참여했다면 정상적으로 참여")
@@ -223,17 +219,16 @@ class EventParticipationServiceTest {
         EventMetadataRepository emRepository = mock(EventMetadataRepository.class);
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(
                 EventMetadata.builder()
-                        .startTime(LocalDateTime.of(2024,8,1,0,0,0))
-                        .endTime(LocalDateTime.of(2024,9,2,0,0,0))
+                        .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
+                        .endTime(LocalDateTime.of(2024, 9, 2, 0, 0, 0))
                         .eventType(EventType.draw)
-                        .drawEvent(new DrawEvent())
                         .build()
         ));
-        LocalDateTime now = LocalDateTime.of(2024,9,1,0,0,0);
+        LocalDateTime now = LocalDateTime.of(2024, 9, 1, 0, 0, 0);
 
         EventParticipationInfoRepository epiRepository = mock(EventParticipationInfoRepository.class);
         // 오늘 참여함
-        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any())).thenReturn(false);
+        when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any())).thenReturn(false);
 
         EventUserRepository euRepository = mock(EventUserRepository.class);
         // 유저 있음
@@ -241,7 +236,7 @@ class EventParticipationServiceTest {
 
         EventParticipationService service = new EventParticipationService(epiRepository, emRepository, euRepository);
         service.participateAtDate("test", "any", now);
-        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(),any(),any(),any());
+        verify(epiRepository, atLeastOnce()).existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any());
         verify(epiRepository, atLeastOnce()).save(any());
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #73

# 📝 작업 내용
 - [x] 이벤트에 대한 댓글 검색 기능 추가
 - [x] EventMetadata에서 DrawEvent를 Lazy Loading 할 수 있도록 OneToMany 관계로 변경, 외부적으로는 OneToOne 처럼 사용할 수 있도록 getter / setter 구현

EventMetadata와 DrawEvent는 1대 1 관계를 가지고 있어 OneToOne relation으로 연결하는 것이 자연스럽지만, JPA의 동작 상 외래키가 없는 측의 엔티티를 가져올 때 반드시 Eager Loading 하는 문제가 있습니다. 이로 인해 관리자 페이지에서 EventMetadata를 요청할 때 DrawEvent까지 함께 가져오는 현상이 발생했습니다. 이 문제를 해결하기 위해 OneToMany 관계로 우회하여 처리했습니다.
