### PR TITLE
[feat] 당첨자 목록 조회 기능 구현 (#80)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -1,28 +1,48 @@
 package hyundai.softeer.orange.admin.controller;
 
+import hyundai.softeer.orange.common.ErrorResponse;
+import hyundai.softeer.orange.event.draw.dto.ResponseDrawWinnerDto;
 import hyundai.softeer.orange.event.draw.service.DrawEventService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
+@Tag(name = "AdminDrawEvent", description = "어드민 추첨 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/draw")
 @RestController
 public class AdminDrawEventController {
     private final DrawEventService drawEventService;
+
     /**
      * @param eventId 추첨할 이벤트 id
      */
-    @Operation(summary = "추첨을 진행한다.", description = "현재 종료된 이벤트의 추첨을 진행한다. 추첨 결과는 기다리지 않는다.")
+    @Operation(summary = "추첨을 진행한다.", description = "현재 종료된 이벤트의 추첨을 진행한다. 추첨 결과는 기다리지 않는다.", responses = {
+            @ApiResponse(responseCode = "200", description = "추첨 성공"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
     @PostMapping("{eventId}/draw")
     public ResponseEntity<Void> drawEvent(@PathVariable("eventId") String eventId) {
         drawEventService.draw(eventId);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * @param eventId 추첨할 이벤트 id
+     */
+    @Operation(summary = "당첨 유저 목록 조회", description = "특정 이벤트의 추첨 결과 당첨된 총 유저 목록을 조회한다.", responses = {
+            @ApiResponse(responseCode = "200", description = "당첨 유저 목록 조회 성공", content = @Content(schema = @Schema(implementation = ResponseDrawWinnerDto.class))),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없는 경우", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("{eventId}/winners")
+    public ResponseEntity<List<ResponseDrawWinnerDto>> getWinners(@PathVariable("eventId") String eventId) {
+        return ResponseEntity.ok(drawEventService.getDrawEventWinner(eventId));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
+++ b/src/main/java/hyundai/softeer/orange/comment/repository/CommentRepository.java
@@ -5,6 +5,8 @@ import hyundai.softeer.orange.comment.dto.WriteCommentCountDto;
 import hyundai.softeer.orange.comment.entity.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -25,6 +27,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long>, JpaSpec
     // 오늘 날짜 기준으로 이미 유저의 기대평이 등록되어 있는지 확인 (JPQL)
     @Query("SELECT (COUNT(c) > 0) FROM Comment c WHERE c.eventUser.id = :eventUserId AND FUNCTION('DATE', c.createdAt) = CURRENT_DATE")
     boolean existsByCreatedDateAndEventUser(@Param("eventUserId") Long eventUserId);
+
+    @EntityGraph(attributePaths = {"eventUser"})
+    Page<Comment> findAll(Specification<Comment> spec, Pageable pageable);
 
     @Query(value = "SELECT c.* FROM comment c " +
             "JOIN event_frame ef ON c.event_frame_id = ef.id " +

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/ResponseDrawWinnerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/ResponseDrawWinnerDto.java
@@ -1,0 +1,23 @@
+package hyundai.softeer.orange.event.draw.dto;
+
+import hyundai.softeer.orange.event.draw.entity.DrawEventWinningInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResponseDrawWinnerDto {
+    private Long ranking;
+    private String name;
+    private String phoneNumber;
+
+    public ResponseDrawWinnerDto(DrawEventWinningInfo drawEventWinningInfo) {
+        this.ranking = drawEventWinningInfo.getRanking();
+        this.name = drawEventWinningInfo.getEventUser().getUserName();
+        this.phoneNumber = drawEventWinningInfo.getEventUser().getPhoneNumber();
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEventWinningInfo.java
@@ -2,10 +2,13 @@ package hyundai.softeer.orange.event.draw.entity;
 
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Table(name="draw_event_winning_info")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class DrawEventWinningInfo {
     @Id
@@ -23,4 +26,11 @@ public class DrawEventWinningInfo {
     @JoinColumn(name = "event_user_id")
     private EventUser eventUser;
 
+    public static DrawEventWinningInfo of(Long ranking, DrawEvent drawEvent, EventUser eventUser) {
+        DrawEventWinningInfo drawEventWinningInfo = new DrawEventWinningInfo();
+        drawEventWinningInfo.ranking = ranking;
+        drawEventWinningInfo.drawEvent = drawEvent;
+        drawEventWinningInfo.eventUser = eventUser;
+        return drawEventWinningInfo;
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventWinningInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventWinningInfoRepository.java
@@ -1,8 +1,12 @@
 package hyundai.softeer.orange.event.draw.repository;
 
 import hyundai.softeer.orange.event.draw.entity.DrawEventWinningInfo;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 public interface DrawEventWinningInfoRepository extends JpaRepository<DrawEventWinningInfo, Long>, CustomDrawEventWinningInfoRepository {
+    @EntityGraph(attributePaths = {"eventUser"})
+    List<DrawEventWinningInfo> findAllById(Long id);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -43,7 +43,7 @@ public class DrawEventService {
         // 이벤트가 존재하는지 검사
         EventMetadata event = emRepository.findFirstByEventId(drawEventId)
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
-        DrawEvent drawEvent = event.getDrawEventList().stream().findFirst().orElse(null);
+        DrawEvent drawEvent = event.getDrawEvent();
         if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
         // 이벤트 검증
         validateDrawCondition(event, LocalDateTime.now());
@@ -70,8 +70,7 @@ public class DrawEventService {
         // 이벤트가 존재하는지 검사
         EventMetadata event = emRepository.findFirstByEventId(drawEventId)
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
-        // IndexOutofBoundsException 방지
-        DrawEvent drawEvent = event.getDrawEventList().stream().findFirst().orElse(null);
+        DrawEvent drawEvent = event.getDrawEvent();
         if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
 
         // 당첨자 목록 반환

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -6,8 +6,10 @@ import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import hyundai.softeer.orange.event.common.enums.EventType;
 import hyundai.softeer.orange.event.common.exception.EventException;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
+import hyundai.softeer.orange.event.draw.dto.ResponseDrawWinnerDto;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import hyundai.softeer.orange.event.draw.exception.DrawEventException;
+import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -27,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 public class DrawEventService {
     private static final Logger log = LoggerFactory.getLogger(DrawEventService.class);
     private final EventMetadataRepository emRepository;
+    private final DrawEventWinningInfoRepository deWinningInfoRepository;
     private final DrawEventDrawMachine machine;
     private final StringRedisTemplate redisTemplate;
 
@@ -39,7 +43,8 @@ public class DrawEventService {
         // 이벤트가 존재하는지 검사
         EventMetadata event = emRepository.findFirstByEventId(drawEventId)
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
-        DrawEvent drawEvent = event.getDrawEventList().get(0);
+        DrawEvent drawEvent = event.getDrawEventList().stream().findFirst().orElse(null);
+        if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
         // 이벤트 검증
         validateDrawCondition(event, LocalDateTime.now());
         String key = EventConst.IS_DRAWING(event.getEventId());
@@ -54,6 +59,26 @@ public class DrawEventService {
             if(throwable != null) log.error(throwable.getMessage(), throwable);
             return null;
         });
+    }
+
+    /**
+     * 추첨 이벤트에 당첨된 사용자들을 반환하는 메서드
+     * @param drawEventId draw event의 id 값
+     */
+    @Transactional(readOnly = true)
+    public List<ResponseDrawWinnerDto> getDrawEventWinner(String drawEventId) {
+        // 이벤트가 존재하는지 검사
+        EventMetadata event = emRepository.findFirstByEventId(drawEventId)
+                .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        // IndexOutofBoundsException 방지
+        DrawEvent drawEvent = event.getDrawEventList().stream().findFirst().orElse(null);
+        if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
+
+        // 당첨자 목록 반환
+        return deWinningInfoRepository.findAllById(drawEvent.getId())
+                .stream()
+                .map(ResponseDrawWinnerDto::new)
+                .toList();
     }
 
     private void tryDraw(String key) {

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,4 +15,5 @@ public class ResponseFcfsWinnerDto {
 
     private String name;
     private String phoneNumber;
+    private LocalDateTime winningTime;
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Table(name="fcfs_event_winning_info")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,10 +25,13 @@ public class FcfsEventWinningInfo {
     @JoinColumn(name ="event_user_id")
     private EventUser eventUser;
 
-    public static FcfsEventWinningInfo of(FcfsEvent fcfsEvent, EventUser eventUser) {
+    private LocalDateTime winningTime;
+
+    public static FcfsEventWinningInfo of(FcfsEvent fcfsEvent, EventUser eventUser, LocalDateTime winningTime) {
         FcfsEventWinningInfo fcfsEventWinningInfo = new FcfsEventWinningInfo();
         fcfsEventWinningInfo.fcfsEvent = fcfsEvent;
         fcfsEventWinningInfo.eventUser = eventUser;
+        fcfsEventWinningInfo.winningTime = winningTime;
         return fcfsEventWinningInfo;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventWinningInfoRepository.java
@@ -10,8 +10,8 @@ import java.util.List;
 @Repository
 public interface FcfsEventWinningInfoRepository extends JpaRepository<FcfsEventWinningInfo, Long> {
 
-    // Fetch Join으로 eventUser 정보까지 한번에 가져와서 N+1 문제 방지
-    @Query("select f from FcfsEventWinningInfo f join fetch f.eventUser where f.fcfsEvent.id = :eventSequence")
+    // Fetch Join으로 eventUser 정보까지 한번에 가져와서 N+1 문제 방지하며, 당첨 시각 기준 오름차순 정렬
+    @Query("select f from FcfsEventWinningInfo f join fetch f.eventUser where f.fcfsEvent.id = :eventSequence order by f.winningTime asc")
     List<FcfsEventWinningInfo> findByFcfsEventId(Long eventSequence);
 
     boolean existsByEventUserIdAndFcfsEventId(Long eventUserId, Long fcfsEventId);

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -59,7 +59,7 @@ public class DbFcfsService implements FcfsService{
             return false;
         }
 
-        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser));
+        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser, LocalDateTime.now()));
         log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
         return true;
     }

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
@@ -210,8 +210,9 @@ class FcfsManageServiceTest {
     @Test
     void getFcfsWinnersInfoTest() {
         // given
+        LocalDateTime now = LocalDateTime.now();
         given(fcfsEventWinningInfoRepository.findByFcfsEventId(eventSequence))
-                .willReturn(List.of(FcfsEventWinningInfo.of(fcfsEvent, eventUser)));
+                .willReturn(List.of(FcfsEventWinningInfo.of(fcfsEvent, eventUser, now)));
 
         // when
         List<ResponseFcfsWinnerDto> fcfsWinnersInfo = fcfsManageService.getFcfsWinnersInfo(eventSequence);
@@ -220,5 +221,6 @@ class FcfsManageServiceTest {
         assertThat(fcfsWinnersInfo).hasSize(1);
         assertThat(fcfsWinnersInfo.get(0).getName()).isEqualTo(eventUser.getUserName());
         assertThat(fcfsWinnersInfo.get(0).getPhoneNumber()).isEqualTo(eventUser.getPhoneNumber());
+        assertThat(fcfsWinnersInfo.get(0).getWinningTime()).isEqualTo(now);
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #80 

# 📝 작업 내용

> 어드민 페이지에서 사용될 당첨자 목록 조회 기능을 신속하게 구현하였습니다.
>
> 원래는 EventUserService에서 구현하려 했으나, 현 EventUserService가 사실상 Auth를 담당하고 있다는 점, DrawEventService에 존재하는 것이 관심사 분리에 부합한다는 점에서 DrawEventService 내부에 구현했습니다.
>
> 한편, DrawEventService의 단위 테스트가 중복되는 코드가 많고 어떤 걸 예외처리하는지 모호한 부분이 있어 전체적으로 리팩토링했습니다. 
>
> 다음으로, 선착순 이벤트 당첨자(FcfsEventWinningInfo) 엔티티 내부에 타임스탬프를 삽입하여 추후 순서를 고려해야 할 때 확장성이 있도록 개편했습니다.
> 
> 마지막으로, 현 댓글 검색 기능과 관련된 쿼리(findAll)가 N+1 문제가 발생하고 있어, @EntityGraph 옵션을 통해 연관 데이터 EventUser를 함께 가져오도록 수정했습니다. (로컬에서 검증 완료되었습니다.) 
**일반적으로 ManyToOne 관계 엔티티에서 One에 해당하는 부분을 가져올 때는 페이징 이슈가 없는 것으로 확인하였습니다.**

<img width="1303" alt="image" src="https://github.com/user-attachments/assets/6e32d5d5-370f-43c8-b0b9-c3db70c707e5">
<img width="1573" alt="image" src="https://github.com/user-attachments/assets/8ac6456a-6364-432f-b68c-a82bc4b87fd8">

- [x] 추첨 이벤트 당첨자 목록 조회 기능 구현
- [x] 선착순 이벤트 당첨자 테이블에 타임스탬프 삽입
- [x] 테스트코드 반영
- [x] 댓글 검색 쿼리 N+1 문제 해결

## 참고 이미지 및 자료
[JPA OneToMany 관계에서 페이징 처리 Dive Deep](https://youngminz.netlify.app/posts/jpa-paging-with-onetomany-deep-dive)
[JPA 모든 N+1 발생 케이스과 해결책](https://jinyoungchoi95.tistory.com/40)

# 💬 리뷰 요구사항
