### PR TITLE
[chore] swagger에 이벤트 유저 인증 api 명시(#86)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -2,6 +2,9 @@ package hyundai.softeer.orange.admin.controller;
 
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.event.draw.dto.ResponseDrawWinnerDto;
+import hyundai.softeer.orange.core.auth.Auth;
+import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
 import hyundai.softeer.orange.event.draw.service.DrawEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,9 +21,9 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/draw")
 @RestController
+@AdminAuthRequirement @Auth({AuthRole.admin})
 public class AdminDrawEventController {
     private final DrawEventService drawEventService;
-
     /**
      * @param eventId 추첨할 이벤트 id
      */

--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -6,6 +6,7 @@ import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
 import hyundai.softeer.orange.eventuser.dto.EventUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,7 +40,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getComments(eventFrameId));
     }
 
-    @Auth(AuthRole.event_user)
+    @EventUserAuthRequirement @Auth(AuthRole.event_user)
     @Tag(name = "Comment")
     @PostMapping("/{eventFrameId}")
     @Operation(summary = "기대평 등록", description = "유저가 신규 기대평을 등록한다.", responses = {
@@ -56,7 +57,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto));
     }
 
-    @Auth(AuthRole.event_user)
+    @EventUserAuthRequirement @Auth(AuthRole.event_user)
     @Tag(name = "Comment")
     @GetMapping("/info")
     @Operation(summary = "기대평 등록 가능 여부 조회", description = "오늘 기대평 등록 가능 여부를 조회한다.", responses = {

--- a/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.event.draw.controller;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
 import hyundai.softeer.orange.event.draw.dto.EventParticipationDatesDto;
 import hyundai.softeer.orange.event.draw.service.EventParticipationService;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
@@ -14,8 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,11 +22,9 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/event/draw")
 @RestController
-@Auth({AuthRole.event_user})
+@EventUserAuthRequirement @Auth({AuthRole.event_user})
 public class DrawEventController {
-    private static final Logger log = LoggerFactory.getLogger(DrawEventController.class);
     private final EventParticipationService epService;
-
     /**
      *
      * @param eventId 이벤트의 id

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
@@ -33,10 +33,6 @@ public class DrawEventDrawMachine {
     @Async
     @Transactional
     public CompletableFuture<Void> draw(DrawEvent drawEvent) {
-        try {
-            Thread.sleep(10000);
-        } catch (Exception e) {}
-
         long drawEventRawId = drawEvent.getId();
         // 점수 계산. 추후 추첨 과정과 분리될 수도 있음.
         List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.event.fcfs.controller;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
 import hyundai.softeer.orange.event.fcfs.dto.RequestAnswerDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsInfoDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsResultDto;
@@ -31,7 +32,7 @@ public class FcfsController {
     private final FcfsAnswerService fcfsAnswerService;
     private final FcfsManageService fcfsManageService;
 
-    @Auth(AuthRole.event_user)
+    @EventUserAuthRequirement @Auth(AuthRole.event_user)
     @PostMapping("/{eventSequence}")
     @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패",
@@ -56,7 +57,7 @@ public class FcfsController {
         return ResponseEntity.ok(fcfsManageService.getFcfsInfo(eventSequence));
     }
 
-    @Auth(AuthRole.event_user)
+    @EventUserAuthRequirement @Auth(AuthRole.event_user)
     @GetMapping("/{eventSequence}/participated")
     @Operation(summary = "선착순 이벤트 참여 여부 조회", description = "정답을 맞혀서 선착순 이벤트에 참여했는지 여부를 조회한다. (당첨은 별도)", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트의 정답을 맞혀서 참여했는지에 대한 결과",


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #86

# 📝 작업 내용

- [x] api 경로에 누락된 인증 필요 어노테이션 추가
- [x] DrawEventDrawMachine에 남아 있던 테스트 목적 코드를 제거

## 참고 이미지 및 자료
![image](https://github.com/user-attachments/assets/23c9b6d0-0ab3-40e9-b592-ddf47bcda713)

이제 유저 API도 인증 필요 여부를 swagger 상에서 바로 알 수 있습니다.