### PR TITLE
[feat] 추첨 이벤트 현재 상태 API 구현(#88)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -1,6 +1,7 @@
 package hyundai.softeer.orange.admin.controller;
 
 import hyundai.softeer.orange.common.ErrorResponse;
+import hyundai.softeer.orange.event.draw.dto.DrawEventStatusDto;
 import hyundai.softeer.orange.event.draw.dto.ResponseDrawWinnerDto;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
@@ -47,5 +48,18 @@ public class AdminDrawEventController {
     @GetMapping("{eventId}/winners")
     public ResponseEntity<List<ResponseDrawWinnerDto>> getWinners(@PathVariable("eventId") String eventId) {
         return ResponseEntity.ok(drawEventService.getDrawEventWinner(eventId));
+    }
+
+
+    @Operation(summary = "추첨 이벤트의 현재 상태를 얻는다.", description = "추첨 이벤트의 현재 상태를 얻는다. 추첨 이벤트의 상태는 추첨 불가, 추첨 가능, 추첨 중, 추첨 완료 중 하나의 값을 가진다.", responses = {
+            @ApiResponse(responseCode = "200", description = "추첨 이벤트 현재 상태 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 이벤트", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @GetMapping("/{eventId}/status")
+    public ResponseEntity<DrawEventStatusDto> getEventStatus(
+            @PathVariable("eventId") String eventId
+    ) {
+        DrawEventStatusDto result = drawEventService.getDrawEventStatus(eventId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -70,7 +70,7 @@ public class EventMetadata {
     }
 
     public boolean isEnded(LocalDateTime now) {
-        return this.status == EventStatus.COMPLETE || endTime.isAfter(now);
+        return (this.status == EventStatus.COMPLETE) || endTime.isBefore(now);
     }
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -69,6 +69,10 @@ public class EventMetadata {
         this.url = url;
     }
 
+    public boolean isEnded(LocalDateTime now) {
+        return this.status == EventStatus.COMPLETE || endTime.isAfter(now);
+    }
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_frame_id")
     private EventFrame eventFrame;

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/DrawEventStatusDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/DrawEventStatusDto.java
@@ -1,0 +1,20 @@
+package hyundai.softeer.orange.event.draw.dto;
+
+import hyundai.softeer.orange.event.draw.enums.DrawEventStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class DrawEventStatusDto {
+    public String eventId;
+    public DrawEventStatus status;
+
+    public static DrawEventStatusDto of(String eventId, DrawEventStatus status) {
+        DrawEventStatusDto dto = new DrawEventStatusDto();
+        dto.eventId = eventId;
+        dto.status = status;
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/enums/DrawEventStatus.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/enums/DrawEventStatus.java
@@ -1,0 +1,8 @@
+package hyundai.softeer.orange.event.draw.enums;
+
+public enum DrawEventStatus {
+    BEFORE_END,
+    AVAILABLE,
+    IS_DRAWING,
+    COMPLETE
+}

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -132,7 +132,7 @@ public class DrawEventService {
         else {
             String key = EventConst.IS_DRAWING(event.getEventId());
             String value = redisTemplate.opsForValue().get(key);
-            if (value == null) status = DrawEventStatus.IS_DRAWING;
+            if (value != null) status = DrawEventStatus.IS_DRAWING;
         }
 
         return DrawEventStatusDto.of(event.getEventId(), status);

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -52,13 +52,15 @@ public class DrawEventService {
         String key = EventConst.IS_DRAWING(event.getEventId());
         tryDraw(key);
 
+        log.info("Event [{}]: start draw", event.getEventId());
         machine.draw(drawEvent)
         // 시간 제한
         .orTimeout(EventConst.DRAW_EVENT_DRAW_TIMEOUT_HOUR, TimeUnit.HOURS)
         // 예외가 발생하더라도 추첨이 끝나면 키를 제거해야 함 = release
         .handleAsync((unused, throwable) -> {
             releaseDraw(key);
-            if(throwable != null) log.error(throwable.getMessage(), throwable);
+            log.info("Event [{}]: finish draw", event.getEventId());
+            if(throwable != null) log.error("Event[{}]", event.getEventId(), throwable);
             return null;
         });
     }

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -238,7 +238,7 @@ class DrawEventServiceTest {
     @DisplayName("getDrawEventStatus: 이벤트가 종료되지 않았다면 BEFORE_END")
     @Test
     void getDrawEventStatus_EventNotEnded() {
-        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(-10);
+        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
         EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
         metadata.updateDrawEvent(new DrawEvent());
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
@@ -253,8 +253,8 @@ class DrawEventServiceTest {
         var drawEvent = new DrawEvent();
         drawEvent.setDrawn(true);
 
-        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
-        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        LocalDateTime endedTime = LocalDateTime.now().plusDays(-10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, endedTime);
         metadata.updateDrawEvent(drawEvent);
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
 
@@ -266,8 +266,8 @@ class DrawEventServiceTest {
     @Test
     void getDrawEventStatus_EventIsDrawing() {
         var drawEvent = new DrawEvent();
-        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
-        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        LocalDateTime endedTime = LocalDateTime.now().plusDays(-10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, endedTime);
         metadata.updateDrawEvent(drawEvent);
 
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
@@ -284,8 +284,8 @@ class DrawEventServiceTest {
     @Test
     void getDrawEventStatus_EventIsAvailable() {
         var drawEvent = new DrawEvent();
-        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
-        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        LocalDateTime endedTime = LocalDateTime.now().plusDays(-10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, endedTime);
         metadata.updateDrawEvent(drawEvent);
 
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -8,6 +8,7 @@ import hyundai.softeer.orange.event.common.exception.EventException;
 import hyundai.softeer.orange.event.common.repository.EventMetadataRepository;
 import hyundai.softeer.orange.event.draw.entity.DrawEvent;
 import hyundai.softeer.orange.event.draw.entity.DrawEventWinningInfo;
+import hyundai.softeer.orange.event.draw.enums.DrawEventStatus;
 import hyundai.softeer.orange.event.draw.exception.DrawEventException;
 import hyundai.softeer.orange.event.draw.repository.DrawEventWinningInfoRepository;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
@@ -206,5 +207,94 @@ class DrawEventServiceTest {
         assertThat(result).isNotEmpty();
         verify(emRepository, times(1)).findFirstByEventId(eventId);
         verify(deWinningInfoRepository, times(1)).findAllById(drawEvent.getId());
+    }
+
+    @DisplayName("getDrawEventStatus: 대응되는 이벤트가 존재하지 않으면 예외 반환")
+    @Test
+    void getDrawEventStatus_throwIfDrawEventNotFound() {
+        var fcfsEventMetadata = createEventMetadata(eventId, EventType.fcfs, LocalDateTime.now());
+        var withoutDrawEvent = createEventMetadata(eventId, EventType.draw, LocalDateTime.now());
+
+        when(emRepository.findFirstByEventId(eventId))
+                .thenReturn(Optional.empty()) // 이벤트 없는 경우
+                .thenReturn(Optional.of(fcfsEventMetadata)) // 이벤트가 draw 아닌 경우
+                .thenReturn(Optional.of(withoutDrawEvent));
+
+        // when & then
+        // 이벤트 없음
+        assertThatThrownBy(() -> deService.draw(eventId))
+                .isInstanceOf(EventException.class)
+                .hasMessage(ErrorCode.EVENT_NOT_FOUND.getMessage());
+        // 이벤트 draw 아님
+        assertThatThrownBy(() -> deService.draw(eventId))
+                .isInstanceOf(DrawEventException.class)
+                .hasMessage(ErrorCode.EVENT_NOT_FOUND.getMessage());
+        // 대응되는 draw 객체가 없음
+        assertThatThrownBy(() -> deService.draw(eventId))
+                .isInstanceOf(DrawEventException.class)
+                .hasMessage(ErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("getDrawEventStatus: 이벤트가 종료되지 않았다면 BEFORE_END")
+    @Test
+    void getDrawEventStatus_EventNotEnded() {
+        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(-10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        metadata.updateDrawEvent(new DrawEvent());
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
+
+        var dto = deService.getDrawEventStatus(eventId);
+        assertThat(dto.getStatus()).isEqualTo(DrawEventStatus.BEFORE_END);
+    }
+
+    @DisplayName("getDrawEventStatus: 이벤트가 종료되었다면 COMPLETE")
+    @Test
+    void getDrawEventStatus_EventIsDrawn() {
+        var drawEvent = new DrawEvent();
+        drawEvent.setDrawn(true);
+
+        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        metadata.updateDrawEvent(drawEvent);
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
+
+        var dto = deService.getDrawEventStatus(eventId);
+        assertThat(dto.getStatus()).isEqualTo(DrawEventStatus.COMPLETE);
+    }
+
+    @DisplayName("getDrawEventStatus: redis에 키가 있다면 추첨 중")
+    @Test
+    void getDrawEventStatus_EventIsDrawing() {
+        var drawEvent = new DrawEvent();
+        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        metadata.updateDrawEvent(drawEvent);
+
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
+
+        ValueOperations<String, String> valueOperation = mock(ValueOperations.class);
+        when(valueOperation.get(anyString())).thenReturn("2");
+        when(redisTemplate.opsForValue()).thenReturn(valueOperation);
+
+        var dto = deService.getDrawEventStatus(eventId);
+        assertThat(dto.getStatus()).isEqualTo(DrawEventStatus.IS_DRAWING);
+    }
+
+    @DisplayName("getDrawEventStatus: 선행 조건에 매칭되지 않으면 AVAILABLE")
+    @Test
+    void getDrawEventStatus_EventIsAvailable() {
+        var drawEvent = new DrawEvent();
+        LocalDateTime notEndedTime = LocalDateTime.now().plusDays(+10);
+        EventMetadata metadata = createEventMetadata(eventId, EventType.draw, notEndedTime);
+        metadata.updateDrawEvent(drawEvent);
+
+        when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(metadata));
+
+        ValueOperations<String, String> valueOperation = mock(ValueOperations.class);
+        when(valueOperation.get(anyString())).thenReturn(null);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperation);
+
+        var dto = deService.getDrawEventStatus(eventId);
+        assertThat(dto.getStatus()).isEqualTo(DrawEventStatus.AVAILABLE);
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #88 

# 📝 작업 내용

> 추첨 여부를 알려주는 API를 구현했습니다. 추가적으로 추첨 이벤트 관련 로그를 출력하게 하여 추첨 이벤트의 추첨이 정상적으로 진행됬는지 알 수 있게 했습니다.