### PR TITLE
[fix] Prod 환경 기준 API 검증 및 버그 수정 (#89)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -48,7 +48,7 @@ public class CommentController {
                     content = @Content(schema = @Schema(implementation = Boolean.class))),
             @ApiResponse(responseCode = "400", description = "기대평 등록 실패, 지나치게 부정적인 표현으로 간주될 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "해당 정보를 갖는 유저나 이벤트가 존재하지 않을 때",
+            @ApiResponse(responseCode = "404", description = "해당 정보를 갖는 유저나 이벤트가 존재하지 않거나, 당일 인터렉션에 참여하지 않아 기대평을 등록할 수 없을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "409", description = "하루에 여러 번의 기대평을 작성하려 할 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/hyundai/softeer/orange/comment/dto/DeleteCommentsDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/DeleteCommentsDto.java
@@ -2,10 +2,12 @@ package hyundai.softeer.orange.comment.dto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class DeleteCommentsDto {
     @NotNull
     private List<Long> commentIds;

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -19,6 +19,7 @@ import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
@@ -103,6 +104,7 @@ public class CommentService {
     }
 
     @Transactional
+    @CacheEvict(value = "comments", allEntries = true)
     public void deleteComments(List<Long> commentIds) {
         commentRepository.deleteAllById(commentIds);
         log.info("deleted comments: {}", commentIds);

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
@@ -1,6 +1,7 @@
 package hyundai.softeer.orange.event.fcfs.scheduler;
 
 import hyundai.softeer.orange.event.fcfs.service.FcfsManageService;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -21,5 +22,11 @@ public class FcfsScheduler {
     @Scheduled(cron = "0 0 0 * * *")
     public void registerWinners() {
         fcfsManageService.registerWinners();
+    }
+
+    // FIXME: 빌드 직후 오늘의 선착순 이벤트에 대한 정보를 DB에서 Redis로 이동시킨다. (추후 삭제예정)
+    @PostConstruct
+    public void init() {
+        registerFcfsEvents();
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #89

# 📝 작업 내용

> 더미 데이터를 생성하여 어드민 관련 일부 API를 제외한 전체적인 API를 Prod 서버 기반으로 검증했습니다. 
> 어드민 기대평 삭제 API에서 발생한 직렬화 관련 에러를 확인하여 수정하였고, 기대평 삭제 시 항상 캐시가 초기화되도록 설정하여 삭제 동작이 바로 반영되도록 하였습니다.
> 또한, 추후 선착순 이벤트의 원활한 시연을 위해 프로젝트 빌드 완료 시 현재 시각 기준 Prod DB에 있는 24시간 이내의 선착순 이벤트의 정보를 Redis에 배치하도록 수정했습니다. 

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
