### PR TITLE
[refactor] 어드민 토큰에 최소한의 내용만 포함되도록 수정(#92)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/component/AdminArgumentResolver.java
+++ b/src/main/java/hyundai/softeer/orange/admin/component/AdminArgumentResolver.java
@@ -1,7 +1,9 @@
 package hyundai.softeer.orange.admin.component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import hyundai.softeer.orange.admin.dto.AdminDto;
 import hyundai.softeer.orange.admin.entity.Admin;
+import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.core.jwt.JWTConst;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -32,12 +34,12 @@ public class AdminArgumentResolver implements HandlerMethodArgumentResolver {
 
     // @Auth에 등록한 클래스라면 아래 코드 정도로 값을 가져올 수 있음
     @Override
-    public Admin resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public AdminDto resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         try {
             Jws<Claims> claims = (Jws<Claims>) request.getAttribute(JWTConst.Token);
-            Object data = claims.getPayload().get("admin");
-            return objectMapper.convertValue(data, Admin.class);
+            Object data = claims.getPayload().get(ConstantUtil.CLAIMS_ADMIN);
+            return objectMapper.convertValue(data, AdminDto.class);
         } catch (Exception e) {
             log.error(e.getMessage());
             return null;

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminAuthController.java
@@ -39,17 +39,17 @@ public class AdminAuthController {
     }
 
 
-    /**
-     * @param dto 관리자 유저 생성을 위한 정보
-     */
-    @PostMapping("/signup")
-    @Operation(summary = "관리자 유저를 생성한다.", description = "관리자 유저를 생성한다. (1명 내부적으로 만든 후 막을 예정)", responses = {
-            @ApiResponse(responseCode = "201", description = "관리자 유저 생성"),
-            @ApiResponse(responseCode = "409", description = "이미 존재하는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 에러. 백엔드에 알림 요망", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-    })
-    public ResponseEntity<Void> signUp(@Valid @RequestBody AdminSignupRequest dto) {
-            adminAuthService.signUp(dto.getUserName(), dto.getPassword(), dto.getNickName());
-            return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
+//    /**
+//     * @param dto 관리자 유저 생성을 위한 정보
+//     */
+//    @PostMapping("/signup")
+//    @Operation(summary = "관리자 유저를 생성한다.", description = "관리자 유저를 생성한다. (1명 내부적으로 만든 후 막을 예정)", responses = {
+//            @ApiResponse(responseCode = "201", description = "관리자 유저 생성"),
+//            @ApiResponse(responseCode = "409", description = "이미 존재하는 유저", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+//            @ApiResponse(responseCode = "500", description = "서버 내부 에러. 백엔드에 알림 요망", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+//    })
+//    public ResponseEntity<Void> signUp(@Valid @RequestBody AdminSignupRequest dto) {
+//            adminAuthService.signUp(dto.getUserName(), dto.getPassword(), dto.getNickName());
+//            return ResponseEntity.status(HttpStatus.CREATED).build();
+//    }
 }

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -1,7 +1,7 @@
 package hyundai.softeer.orange.admin.controller;
 
 import hyundai.softeer.orange.admin.component.AdminAnnotation;
-import hyundai.softeer.orange.admin.entity.Admin;
+import hyundai.softeer.orange.admin.dto.AdminDto;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
@@ -68,7 +68,7 @@ public class AdminEventController {
             @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패")
     })
     public ResponseEntity<Void> createEvent(@Validated @RequestBody EventDto eventDto,
-                                            @Parameter(hidden = true) @AdminAnnotation Admin admin
+                                            @Parameter(hidden = true) @AdminAnnotation AdminDto admin
     ) {
         // 나중에 두개 과정을 통합할 수도 있음.
         eventService.createEvent(eventDto);
@@ -133,7 +133,7 @@ public class AdminEventController {
     @Operation(summary = "임시 저장 된 이벤트 불러오기", description = "관리자가 이벤트 프레임을 새롭게 등록한다", responses = {
             @ApiResponse(responseCode = "200", description = "이벤트 불러오기 성공"),
     })
-    public ResponseEntity<EventDto> getTempEvent(@Parameter(hidden = true) @AdminAnnotation Admin admin) {
+    public ResponseEntity<EventDto> getTempEvent(@Parameter(hidden = true) @AdminAnnotation AdminDto admin) {
         Long adminId = admin.getId();
         EventDto eventDto = eventService.getTempEvent(adminId);
         return ResponseEntity.ok(eventDto);
@@ -149,7 +149,7 @@ public class AdminEventController {
 
     })
     public ResponseEntity<Void> saveTempEvent(@RequestBody EventDto eventDto,
-                                              @Parameter(hidden = true) @AdminAnnotation Admin admin) {
+                                              @Parameter(hidden = true) @AdminAnnotation AdminDto admin) {
         Long adminId = admin.getId();
         eventService.saveTempEvent(adminId, eventDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/hyundai/softeer/orange/admin/dto/AdminDto.java
+++ b/src/main/java/hyundai/softeer/orange/admin/dto/AdminDto.java
@@ -1,0 +1,18 @@
+package hyundai.softeer.orange.admin.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminDto {
+    private Long id;
+    private String nickname;
+
+    public static AdminDto of(Long id, String nickname) {
+        AdminDto adminDto = new AdminDto();
+        adminDto.id = id;
+        adminDto.nickname = nickname;
+        return adminDto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/admin/service/AdminAuthService.java
+++ b/src/main/java/hyundai/softeer/orange/admin/service/AdminAuthService.java
@@ -1,10 +1,13 @@
 package hyundai.softeer.orange.admin.service;
 
+import hyundai.softeer.orange.admin.dto.AdminDto;
 import hyundai.softeer.orange.admin.entity.Admin;
 import hyundai.softeer.orange.admin.exception.AdminException;
 import hyundai.softeer.orange.admin.repository.AdminRepository;
 import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.jwt.JWTConst;
 import hyundai.softeer.orange.core.jwt.JWTManager;
 import hyundai.softeer.orange.core.security.PasswordManager;
 import lombok.RequiredArgsConstructor;
@@ -31,15 +34,13 @@ public class AdminAuthService {
      */
     public String signIn(String username, String password) {
         Optional<Admin> adminOptional = adminRepository.findFirstByUserName(username);
-        if(adminOptional.isEmpty()) throw new AdminException(ErrorCode.AUTHENTICATION_FAILED);
-
-        Admin admin = adminOptional.get();
+        Admin admin = adminOptional.orElseThrow(() -> new AdminException(ErrorCode.AUTHENTICATION_FAILED));
+        AdminDto dto = AdminDto.of(admin.getId(), admin.getNickName());
         String beforePassword = admin.getPassword();
         boolean loginSuccess = pwManager.verify(password, beforePassword);
         if(!loginSuccess) throw new AdminException(ErrorCode.AUTHENTICATION_FAILED);
 
-        // dto를 넣도록 수정하기.
-        return jwtManager.generateToken("admin", Map.of("admin", admin,"role", AuthRole.admin), 5);
+        return jwtManager.generateToken(ConstantUtil.CLAIMS_ADMIN, Map.of(ConstantUtil.CLAIMS_ADMIN, dto, JWTConst.ROLE, AuthRole.admin), 5);
     }
 
     /**

--- a/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
+++ b/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
@@ -13,7 +13,7 @@ public class ConstantUtil {
     public static final String AUTH_CODE_REGEX = "\\d{6}"; // 6자리 숫자
     public static final String AUTH_CODE_CREATE_REGEX = "%06d";
     public static final String CLAIMS_USER_KEY = "userId";
-    public static final String CLAIMS_ROLE_KEY = "role";
+    public static final String CLAIMS_ADMIN = "admin";
     public static final String CLAIMS_USER_NAME_KEY = "userName";
     public static final String JWT_USER_KEY = "eventUser";
     public static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";

--- a/src/main/java/hyundai/softeer/orange/eventuser/component/EventUserArgumentResolver.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/component/EventUserArgumentResolver.java
@@ -34,7 +34,7 @@ public class EventUserArgumentResolver implements HandlerMethodArgumentResolver 
         try {
             Jws<Claims> claims = (Jws<Claims>) request.getAttribute(JWTConst.Token);
             String userId = claims.getPayload().get(ConstantUtil.CLAIMS_USER_KEY).toString();
-            String role = claims.getPayload().get(ConstantUtil.CLAIMS_ROLE_KEY).toString();
+            String role = claims.getPayload().get(JWTConst.ROLE).toString();
             return new EventUserInfo(userId, role);
         } catch (Exception e) {
             throw new EventUserException(ErrorCode.UNAUTHORIZED);

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
@@ -4,6 +4,7 @@ import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.dto.TokenDto;
 import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.jwt.JWTConst;
 import hyundai.softeer.orange.core.jwt.JWTManager;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
@@ -82,7 +83,7 @@ public class EventUserService {
 
     // JWT 토큰 생성
     private TokenDto generateToken(EventUser eventUser) {
-        Map<String, Object> claims = Map.of(ConstantUtil.CLAIMS_USER_KEY, eventUser.getUserId(), ConstantUtil.CLAIMS_ROLE_KEY, AuthRole.event_user,
+        Map<String, Object> claims = Map.of(ConstantUtil.CLAIMS_USER_KEY, eventUser.getUserId(), JWTConst.ROLE, AuthRole.event_user,
                 ConstantUtil.CLAIMS_USER_NAME_KEY, eventUser.getUserName());
         String token = jwtManager.generateToken(ConstantUtil.JWT_USER_KEY, claims, ConstantUtil.JWT_LIFESPAN);
         log.info("JWT Token generated for EventUser {}", eventUser.getUserName());


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #92

# 📝 작업 내용

> JWT 토큰에 어드민 객체를 직접 전달하는 대신 어드민 토큰에 필요한 일부 데이터 (id / 닉네임)만 포함하도록 구성했습니다. 또한 관리자 계정을 마음대로 생성할 수 없도록 API를 비활성화했습니다.