### PR TITLE
[fix] 선착순 이벤트 상태 조회 기능 응답값 수정 (#94)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsInfoDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsInfoDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ResponseFcfsInfoDto {
 
-    private LocalDateTime nowDateTime;
+    private LocalDateTime eventStartTime;
 
     private String eventStatus;
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -93,11 +93,11 @@ public class FcfsManageService {
         // 그 외 -> waiting
         log.info("Checked FCFS event status: {}", eventSequence);
         if(nowDateTime.isBefore(eventStartTime) && nowDateTime.plusHours(ConstantUtil.FCFS_COUNTDOWN_HOUR).isAfter(eventStartTime)) {
-            return new ResponseFcfsInfoDto(nowDateTime, ConstantUtil.COUNTDOWN);
+            return new ResponseFcfsInfoDto(eventStartTime, ConstantUtil.COUNTDOWN);
         } else if(eventStartTime.isBefore(nowDateTime) && eventStartTime.plusHours(ConstantUtil.FCFS_AVAILABLE_HOUR).isAfter(nowDateTime)) {
-            return new ResponseFcfsInfoDto(nowDateTime, ConstantUtil.PROGRESS);
+            return new ResponseFcfsInfoDto(eventStartTime, ConstantUtil.PROGRESS);
         } else {
-            return new ResponseFcfsInfoDto(nowDateTime, ConstantUtil.WAITING);
+            return new ResponseFcfsInfoDto(eventStartTime, ConstantUtil.WAITING);
         }
     }
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #94 

# 📝 작업 내용

> 선착순 이벤트의 상태 조회 기능에서 응답 필드인 현재 시각을 이벤트 시작 예정 시각으로 바꿔달라는 요청이 있어 신속하게 반영했습니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
PR 외적으로 mySQL의 시각이 UST 기준이라, KST로 직접 수정해두었습니다. 다만 Grafana에서 수집되는 로그 자체는 UST인 상황입니다.

환경변수에 spring.jackson.time-zone=Asia/Seoul 옵션을 추가하여, 서버 시각을 KST 기반으로 조정하겠습니다!