### PR TITLE
[refactor] 어드민 댓글 api가 페이지 관련 정보를 함께 반환하도록 수정(#93)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -1,6 +1,6 @@
 package hyundai.softeer.orange.admin.controller;
+import hyundai.softeer.orange.comment.dto.CommentsPageDto;
 import hyundai.softeer.orange.comment.dto.DeleteCommentsDto;
-import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthRole;
@@ -31,7 +31,7 @@ public class AdminCommentController {
             @ApiResponse(responseCode = "200", description = "이벤트에 대한 댓글 목록 조회 성공")
     })
     @GetMapping
-    public ResponseEntity<ResponseCommentsDto> findEventComments(
+    public ResponseEntity<CommentsPageDto> findEventComments(
             @RequestParam String eventId,
             @RequestParam(required=false) String search,
             @RequestParam(required = false, defaultValue = "0") Integer page,

--- a/src/main/java/hyundai/softeer/orange/comment/dto/CommentsPageDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/CommentsPageDto.java
@@ -1,0 +1,38 @@
+package hyundai.softeer.orange.comment.dto;
+
+import hyundai.softeer.orange.comment.entity.Comment;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class CommentsPageDto {
+    /**
+     * 댓글 목록
+     */
+    private List<ResponseCommentDto> comments;
+    /**
+     * 총 페이지 수
+     */
+    private int totalPages;
+
+    /**
+     * 현재 페이지 번호
+     */
+    private int number;
+
+    /**
+     * 페이지 크기
+     */
+    private int size;
+
+    public static CommentsPageDto from(Page<Comment> page) {
+        CommentsPageDto dto = new CommentsPageDto();
+        dto.totalPages = page.getTotalPages();
+        dto.number = page.getNumber();
+        dto.size = page.getSize();
+        dto.comments = page.getContent().stream().map(ResponseCommentDto::from).toList();
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.comment.service;
 
+import hyundai.softeer.orange.comment.dto.CommentsPageDto;
 import hyundai.softeer.orange.comment.dto.CreateCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
@@ -111,7 +112,7 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseCommentsDto searchComments(String eventId, String search, Integer page, Integer size) {
+    public CommentsPageDto searchComments(String eventId, String search, Integer page, Integer size) {
         PageRequest pageInfo = PageRequest.of(page, size);
 
         Specification<Comment> matchEventId = CommentSpecification.matchEventId(eventId);
@@ -120,10 +121,10 @@ public class CommentService {
         var comments = commentRepository.findAll(
                 matchEventId.and(searchOnContent),
                 pageInfo
-        ).stream().map(ResponseCommentDto::from).toList();
+        );
 
         log.info("searched comments: {}", comments);
-        return new ResponseCommentsDto(comments);
+        return CommentsPageDto.from(comments);
     }
 
     private EventUser getEventUser(String userId) {

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.comment;
 
+import hyundai.softeer.orange.comment.dto.CommentsPageDto;
 import hyundai.softeer.orange.comment.dto.CreateCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
@@ -273,7 +274,7 @@ class CommentServiceTest {
         given(commentRepository.findAll(any(Specification.class), any(Pageable.class))).willReturn(new PageImpl<>(List.of(Comment.of("test", eventFrame, eventUser, true))));
 
         // when
-        ResponseCommentsDto dto = commentService.searchComments("event-key", null,0, 10);
+        CommentsPageDto dto = commentService.searchComments("event-key", null,0, 10);
 
         // then
         assertThat(dto.getComments()).hasSize(1);


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #93 

# 📝 작업 내용

> 어드민 댓글 조회 기능도 어드민 이벤트 조회 기능처럼 현재 페이지 등의 정보를 얻을 수 있도록 변경했습니다.