### PR TITLE
[fix] docker-compose 컨테이너 시각 UTC로 설정된 버그 수정 (#99)

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - "8080:8080"
     volumes:
       - /var/log/spring-boot:/var/log/spring-boot
+    environment:
+      - TZ=Asia/Seoul
     networks:
       - my_custom_network
 
@@ -26,6 +28,8 @@ services:
     command:
       - -config.file=/promtail-config.yml
       - -config.expand-env=true  # 환경 변수 확장 활성화
+    environment:
+      - TZ=Asia/Seoul
     networks:
       - my_custom_network
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #94

# 📝 작업 내용

prod 환경의 선착순 이벤트를 테스트하려고 했으나 분명 시각이 지났음에도 지속적으로 이벤트 시간이 아니라는 에러가 발생하고 있었습니다.
Docker 컨테이너 내부에서 시간을 측정한 결과 UST 기준이 설정되어 있어, 도커 컴포즈에 관련 설정을 명시적으로 추가해 주었습니다.

~~~
$ docker exec -it orange  /bin/sh
sh-4.4# date
Mon Aug 19 07:37:14 UTC 2024
~~~

이를 통해 서버 시각 및 로그 수집 시각을 KST로 설정할 수 있을 것입니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
