### PR TITLE
[refactor] 관리자 이벤트 생성 시 이벤트 프레임도 함께 생성할 수 있도록 변경, 이벤트 프레임 검색 api 구현(#98)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -120,11 +120,20 @@ public class AdminEventController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @GetMapping("/frame/hints")
+    @Operation(summary="이벤트 프레임 힌트 목록 얻기",description = "관리자가 이벤트를 생성할 때 존재하는 이벤트 프레임을 검색한다. 매칭되는 프레임 id를 가져온다.", responses = {
+            @ApiResponse(responseCode = "200", description = "매칭되는 이벤트 힌트 목록을 가져온다.")
+    })
+    public ResponseEntity<EventFrameIdListDto> findEventFrameSearchHints(@RequestParam(value = "search", defaultValue = "") String search) {
+        var frameSearchHints = eventService.searchFrames(search);
+        return ResponseEntity.ok(frameSearchHints);
+    }
+
     @GetMapping("/hints")
     @Operation(summary="이벤트 힌트 목록 얻기", description = "관리자가 이벤트 댓글 열람을 위해 검색할 때 반환하는 (이벤트 id / 이름 ) 정보 목록을 얻는다.", responses = {
             @ApiResponse(responseCode = "200", description = "이벤트 힌트 목록 획득")
     })
-    public ResponseEntity<List<EventSearchHintDto>> findEventSearchHints(@RequestParam("search") String search) {
+    public ResponseEntity<List<EventSearchHintDto>> findEventSearchHints(@RequestParam(value = "search", required = false) String search) {
         var searchHints = eventService.searchHints(search);
         return ResponseEntity.ok(searchHints);
     }

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -82,7 +82,7 @@ public class AdminEventController {
      * @return 해당 이벤트에 대한 정보
      */
     @GetMapping("{eventId}")
-    @Operation(summary = "이벤트 데이터 획득", description = "이벤트 초기 정보를 받는다", responses = {
+    @Operation(summary = "이벤트 데이터 획득", description = "이벤트 초기 정보를 받는다. 상세 정보, 이벤트 수정 모두에서 사용 가능", responses = {
             @ApiResponse(responseCode = "200", description = "이벤트 정보를 정상적으로 받음"),
             @ApiResponse(responseCode = "404", description = "대응되는 이벤트가 존재하지 않음")
     })

--- a/src/main/java/hyundai/softeer/orange/admin/controller/EventFrameIdListDto.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/EventFrameIdListDto.java
@@ -1,0 +1,16 @@
+package hyundai.softeer.orange.admin.controller;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class EventFrameIdListDto {
+    private List<String> frameIds;
+
+    public static EventFrameIdListDto of(List<String> frameIds) {
+        EventFrameIdListDto dto = new EventFrameIdListDto();
+        dto.frameIds = frameIds;
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.event.common.repository;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,10 +11,11 @@ import java.util.Optional;
 
 @Repository
 public interface EventFrameRepository extends JpaRepository<EventFrame, Long> {
-    Optional<EventFrame> findByName(String name);
-
     @Query("SELECT ef.frameId FROM EventFrame ef")
     List<String> findAllFrameIds();
 
     Optional<EventFrame> findByFrameId(String frameId);
+
+    @Query("SELECT ef.frameId FROM EventFrame ef WHERE ef.frameId LIKE %:search%")
+    List<String> findAllFrameIdsWithLike(@Param("search") String search);
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -52,10 +52,12 @@ public class EventService {
      */
     @Transactional
     public void createEvent(EventDto eventDto) {
-        // 1. eventframe을 찾는다. 없으면 작업이 의미 X
+        // 1. eventframe을 찾는다. 없으면 만든다.
         Optional<EventFrame> frameOpt = efRepository.findByFrameId(eventDto.getEventFrameId());
-        EventFrame frame = frameOpt
-                .orElseThrow(() -> new EventException(ErrorCode.EVENT_FRAME_NOT_FOUND));
+        EventFrame frame = frameOpt.orElseGet(() -> {
+            EventFrame newFrame = EventFrame.of(eventDto.getEventFrameId(), eventDto.getEventFrameId());
+            return efRepository.save(newFrame);
+        });
 
         String eventKey = keyGenerator.generate();
 
@@ -144,7 +146,7 @@ public class EventService {
     }
 
     /**
-     * 이벤트에 대한 초기 데이터 정보를 제공한다.
+     * 이벤트에 대한 초기 데이터 정보를 제공한다. 수정 + 상세 조회 모두 사용 가능
      * @param eventId 요청한 이벤트의 id
      * @return 이벤트 내용을 담은 dto
      */

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -1,5 +1,6 @@
 package hyundai.softeer.orange.event.common.service;
 
+import hyundai.softeer.orange.admin.controller.EventFrameIdListDto;
 import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.core.ParseUtil;
 import hyundai.softeer.orange.event.common.EventConst;
@@ -272,4 +273,8 @@ public class EventService {
         log.info("Created Event Frame: {}", name);
     }
 
+    public EventFrameIdListDto searchFrames(String search) {
+        var frameIds = efRepository.findAllFrameIdsWithLike(search);
+        return EventFrameIdListDto.of(frameIds);
+    }
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -250,6 +250,7 @@ public class EventService {
      * @param search 이벤트 검색어
      * @return 검색을 위한 힌트 정보 ( id, 이름 )
      */
+    @Transactional(readOnly = true)
     public List<EventSearchHintDto> searchHints(String search) {
         var searchOnEventIdDefaultReject = EventSpecification.searchOnEventId(search, false);
         var isDrawEvent = EventSpecification.isEventTypeOf(EventType.draw);

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -47,15 +47,16 @@ class EventServiceTest {
         MockitoAnnotations.openMocks(this);
     }
 
-    @DisplayName("대응되는 eventframe이 없으면 예외 반환")
+    @DisplayName("대응되는 eventframe이 없으면 생성")
     @Test
     void createEvent_throwErrorIFNoMatchedEventFrame() {
         EventDto eventDto = EventDto.builder().build();
 
         assertThatThrownBy(() -> {
             eventService.createEvent(eventDto);
-        }).isInstanceOf(EventException.class)
-                .hasMessage(ErrorCode.EVENT_FRAME_NOT_FOUND.getMessage());
+        }).isInstanceOf(EventException.class);
+
+        verify(efRepo, times(1)).save(any(EventFrame.class));
     }
 
     @DisplayName("이벤트 타입에 매칭되는 매퍼가 없다면 예외 반환")


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #98

# 📝 작업 내용

> 이벤트 생성 시 대응되는 이벤트 프레임이 없으면 같이 만들도록 기능을 수정했습니다. 또한 현재 존재하는 이벤트 프레임을 검색할 수 있는 api를 구현했습니다.