### PR TITLE
[refactor] 선착순 이벤트 API 매개변수 eventSequenced에서 eventId로 변경 (#101)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/comment/scheduler/CommentScheduler.java
@@ -4,22 +4,39 @@ import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Component
 public class CommentScheduler {
 
+    // 분산 환경에서 메서드가 여러 번 실행되는 것을 방지하기 위해 분산 락 도입
+    private final RedissonClient redissonClient;
     private final CommentService commentService;
     private final EventFrameRepository eventFrameRepository;
 
     // 스케줄러에 의해 일정 시간마다 캐싱된 긍정 기대평 목록을 초기화한다.
     @Scheduled(fixedRate = ConstantUtil.SCHEDULED_TIME) // 2시간마다 실행
-    private void clearCache() {
-        List<String> frameIds = eventFrameRepository.findAllFrameIds();
-        frameIds.forEach(commentService::getComments);
+    private void clearCache() throws InterruptedException {
+        RLock lock = redissonClient.getLock(ConstantUtil.DB_TO_REDIS_LOCK);
+        try {
+            // 5분동안 락 점유
+            if (lock.tryLock(0, 5, TimeUnit.MINUTES)) {
+                try {
+                    List<String> frameIds = eventFrameRepository.findAllFrameIds();
+                    frameIds.forEach(commentService::getComments);
+                } finally {
+                    lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
+++ b/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
@@ -22,6 +22,9 @@ public class ConstantUtil {
     public static final String WAITING = "waiting";
     public static final String PROGRESS = "progress";
 
+    public static final String DB_TO_REDIS_LOCK = "FCFS_MANAGE_DB_TO_REDIS";
+    public static final String REDIS_TO_DB_LOCK = "FCFS_MANAGE_REDIS_TO_DB";
+
     public static final double LIMIT_NEGATIVE_CONFIDENCE = 99.5;
     public static final int COMMENTS_SIZE = 20;
     public static final int SCHEDULED_TIME = 1000 * 60 * 60 * 2;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -33,39 +33,39 @@ public class FcfsController {
     private final FcfsManageService fcfsManageService;
 
     @EventUserAuthRequirement @Auth(AuthRole.event_user)
-    @PostMapping("/{eventSequence}")
+    @PostMapping("/{eventId}")
     @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패",
                     content = @Content(schema = @Schema(implementation = ResponseFcfsResultDto.class))),
             @ApiResponse(responseCode = "400", description = "선착순 이벤트 시간이 아니거나, 요청 형식이 잘못된 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseFcfsResultDto> participate(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence, @RequestBody RequestAnswerDto dto) {
-        boolean answerResult = fcfsAnswerService.judgeAnswer(eventSequence, dto.getAnswer());
-        boolean isWin = answerResult && fcfsService.participate(eventSequence, userInfo.getUserId());
+    public ResponseEntity<ResponseFcfsResultDto> participate(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventId, @RequestBody RequestAnswerDto dto) {
+        boolean answerResult = fcfsAnswerService.judgeAnswer(eventId, dto.getAnswer());
+        boolean isWin = answerResult && fcfsService.participate(eventId, userInfo.getUserId());
         return ResponseEntity.ok(new ResponseFcfsResultDto(answerResult, isWin));
     }
 
-    @GetMapping("/{eventSequence}/info")
+    @GetMapping("/{eventId}/info")
     @Operation(summary = "특정 선착순 이벤트의 정보 조회", description = "특정 선착순 이벤트에 대한 정보(서버 기준 시각, 이벤트의 상태)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트에 대한 상태 정보",
                     content = @Content(schema = @Schema(implementation = ResponseFcfsInfoDto.class))),
             @ApiResponse(responseCode = "404", description = "선착순 이벤트를 찾을 수 없는 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<ResponseFcfsInfoDto> getFcfsInfo(@PathVariable Long eventSequence) {
-        return ResponseEntity.ok(fcfsManageService.getFcfsInfo(eventSequence));
+    public ResponseEntity<ResponseFcfsInfoDto> getFcfsInfo(@PathVariable String eventId) {
+        return ResponseEntity.ok(fcfsManageService.getFcfsInfo(eventId));
     }
 
     @EventUserAuthRequirement @Auth(AuthRole.event_user)
-    @GetMapping("/{eventSequence}/participated")
+    @GetMapping("/{eventId}/participated")
     @Operation(summary = "선착순 이벤트 참여 여부 조회", description = "정답을 맞혀서 선착순 이벤트에 참여했는지 여부를 조회한다. (당첨은 별도)", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트의 정답을 맞혀서 참여했는지에 대한 결과",
                     content = @Content(schema = @Schema(implementation = ResponseFcfsResultDto.class))),
             @ApiResponse(responseCode = "404", description = "선착순 이벤트를 찾을 수 없는 경우",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Boolean> isParticipated(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable Long eventSequence) {
-        return ResponseEntity.ok(fcfsManageService.isParticipated(eventSequence, userInfo.getUserId()));
+    public ResponseEntity<Boolean> isParticipated(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventId) {
+        return ResponseEntity.ok(fcfsManageService.isParticipated(eventId, userInfo.getUserId()));
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
@@ -1,27 +1,58 @@
 package hyundai.softeer.orange.event.fcfs.scheduler;
 
+import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.event.fcfs.service.FcfsManageService;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Component
 public class FcfsScheduler {
 
+    // 분산 환경에서 메서드가 여러 번 실행되는 것을 방지하기 위해 분산 락 도입
+    private final RedissonClient redissonClient;
     private final FcfsManageService fcfsManageService;
 
     // 매일 자정 1분마다 실행되며, 오늘의 선착순 이벤트에 대한 정보를 DB에서 Redis로 이동시킨다.
     @Scheduled(cron = "0 1 0 * * *")
     public void registerFcfsEvents() {
-        fcfsManageService.registerFcfsEvents();
+        RLock lock = redissonClient.getLock(ConstantUtil.DB_TO_REDIS_LOCK);
+        try {
+            // 5분동안 락 점유
+            if (lock.tryLock(0, 5, TimeUnit.MINUTES)) {
+                try {
+                    fcfsManageService.registerFcfsEvents();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // 매일 자정마다 실행되며, 선착순 이벤트 당첨자들을 Redis에서 DB로 이동시킨다.
     @Scheduled(cron = "0 0 0 * * *")
     public void registerWinners() {
-        fcfsManageService.registerWinners();
+        RLock lock = redissonClient.getLock(ConstantUtil.REDIS_TO_DB_LOCK);
+        try {
+            // 5분동안 락 점유
+            if (lock.tryLock(0, 5, TimeUnit.MINUTES)) {
+                try {
+                    fcfsManageService.registerWinners();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     // FIXME: 빌드 직후 오늘의 선착순 이벤트에 대한 정보를 DB에서 Redis로 이동시킨다. (추후 삭제예정)

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -32,7 +32,7 @@ public class DbFcfsService implements FcfsService{
     @Override
     @Transactional
     public boolean participate(String eventId, String userId){
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
             throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
@@ -17,7 +17,7 @@ public class FcfsAnswerService {
 
     public boolean judgeAnswer(String eventId, String answer) {
         // eventId로부터 FCFS의 key를 가져옴
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
@@ -15,9 +15,15 @@ public class FcfsAnswerService {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public boolean judgeAnswer(Long eventSequence, String answer) {
+    public boolean judgeAnswer(String eventId, String answer) {
+        // eventId로부터 FCFS의 key를 가져옴
+        String key = stringRedisTemplate.opsForValue().get(eventId);
+        if(key == null) {
+            throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
+        }
+
         // 잘못된 이벤트 참여 시간
-        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(eventSequence.toString()));
+        String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(key));
         if(startTime == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
@@ -26,7 +32,7 @@ public class FcfsAnswerService {
         }
 
         // 정답 비교
-        String correctAnswer = stringRedisTemplate.opsForValue().get(FcfsUtil.answerFormatting(eventSequence.toString()));
+        String correctAnswer = stringRedisTemplate.opsForValue().get(FcfsUtil.answerFormatting(key));
         if (correctAnswer == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsService.java
@@ -1,6 +1,6 @@
 package hyundai.softeer.orange.event.fcfs.service;
 
 public interface FcfsService {
-    boolean participate(Long eventSequence, String userId);
+    boolean participate(String eventId, String userId);
 
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -26,7 +26,7 @@ public class RedisLockFcfsService implements FcfsService {
 
     @Override
     public boolean participate(String eventId, String userId) {
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
             throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -25,8 +25,13 @@ public class RedisLockFcfsService implements FcfsService {
     private final RedisTemplate<String, Integer> numberRedisTemplate;
 
     @Override
-    public boolean participate(Long eventSequence, String userId) {
-        String key = eventSequence.toString();
+    public boolean participate(String eventId, String userId) {
+        String key = stringRedisTemplate.opsForValue().get(eventId);
+        if(key == null) {
+            throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
+        }
+        Long eventSequence = Long.parseLong(key);
+
         // 이벤트 종료 여부 확인
         if (isEventEnded(key)) {
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -26,8 +26,13 @@ public class RedisLuaFcfsService implements FcfsService {
     private final RedisTemplate<String, Boolean> booleanRedisTemplate;
 
     @Override
-    public boolean participate(Long eventSequence, String userId) {
-        String key = eventSequence.toString();
+    public boolean participate(String eventId, String userId) {
+        String key = stringRedisTemplate.opsForValue().get(eventId);
+        if(key == null) {
+            throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
+        }
+        Long eventSequence = Long.parseLong(key);
+
         // 이벤트 종료 여부 확인
         if (isEventEnded(key)) {
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -27,7 +27,7 @@ public class RedisLuaFcfsService implements FcfsService {
 
     @Override
     public boolean participate(String eventId, String userId) {
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
             throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
@@ -21,8 +21,13 @@ public class RedisSetFcfsService implements FcfsService {
     private final StringRedisTemplate stringRedisTemplate;
 
     @Override
-    public boolean participate(Long eventSequence, String userId) {
-        String key = eventSequence.toString();
+    public boolean participate(String eventId, String userId) {
+        String key = stringRedisTemplate.opsForValue().get(eventId);
+        if(key == null) {
+            throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
+        }
+        Long eventSequence = Long.parseLong(key);
+
         // 이벤트 종료 여부 확인
         if(isEventEnded(key)) {
             stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
@@ -22,7 +22,7 @@ public class RedisSetFcfsService implements FcfsService {
 
     @Override
     public boolean participate(String eventId, String userId) {
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
             throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
         }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -6,6 +6,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FcfsUtil {
 
+    // 선착순 이벤트의 PK를 간접적으로 보관하는 eventId tag
+    public static String eventIdFormatting(String key) {
+        return key + ":eventId";
+    }
+
     // 선착순 이벤트 tag
     public static String keyFormatting(String key) {
         return key + ":fcfs";
@@ -13,22 +18,22 @@ public class FcfsUtil {
 
     // 선착순 이벤트 시작 시각 tag
     public static String startTimeFormatting(String key) {
-        return key + "_start";
+        return key + ":start";
     }
 
     // 선착순 이벤트 마감 여부 tag
     public static String endFlagFormatting(String key) {
-        return key + "_end";
+        return key + ":end";
     }
 
     // 선착순 이벤트 당첨자 tag
     public static String winnerFormatting(String key) {
-        return key + "_winner";
+        return key + ":winner";
     }
 
     // 선착순 이벤트 참여자 tag
     public static String participantFormatting(String key) {
-        return key + "_participant";
+        return key + ":participant";
     }
 
     // 선착순 이벤트 정답 tag

--- a/src/test/java/hyundai/softeer/orange/load/RedisLockFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/load/RedisLockFcfsServiceLoadTest.java
@@ -35,6 +35,7 @@ class RedisLockFcfsServiceLoadTest {
 
     Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
     int numberOfWinners = 100; // 당첨자 수
+    String eventId = "HD_240808_001"; // 이벤트 ID
 
     @BeforeEach
     void setUp() {
@@ -46,6 +47,7 @@ class RedisLockFcfsServiceLoadTest {
         booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), false);
         numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), numberOfWinners);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
+        stringRedisTemplate.opsForValue().set(eventId, eventSequence.toString());
     }
 
     @AfterEach
@@ -72,7 +74,7 @@ class RedisLockFcfsServiceLoadTest {
             final int index = i;
             executorService.execute(() -> {
                 try {
-                    boolean result = redisLockFcfsService.participate(1L, "user" + index);
+                    boolean result = redisLockFcfsService.participate(eventId, "user" + index);
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {

--- a/src/test/java/hyundai/softeer/orange/load/RedisLuaFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/load/RedisLuaFcfsServiceLoadTest.java
@@ -32,6 +32,7 @@ class RedisLuaFcfsServiceLoadTest {
 
     Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
     int numberOfWinners = 100; // 당첨자 수
+    String eventId = "HD_240808_001"; // 이벤트 ID
 
     @BeforeEach
     void setUp() {
@@ -43,6 +44,7 @@ class RedisLuaFcfsServiceLoadTest {
         // 테스트할 이벤트 정보 저장
         numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), numberOfWinners);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
+        stringRedisTemplate.opsForValue().set(eventId, eventSequence.toString());
     }
 
     @Test
@@ -58,7 +60,7 @@ class RedisLuaFcfsServiceLoadTest {
             final int index = i;
             executorService.execute(() -> {
                 try {
-                    boolean result = redisLuaFcfsService.participate(1L, "user" + index);
+                    boolean result = redisLuaFcfsService.participate(eventId, "user" + index);
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {

--- a/src/test/java/hyundai/softeer/orange/load/RedisSetFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/load/RedisSetFcfsServiceLoadTest.java
@@ -35,6 +35,7 @@ class RedisSetFcfsServiceLoadTest {
 
     Long eventSequence = 1L; // 테스트할 이벤트 시퀀스
     int numberOfWinners = 100; // 당첨자 수
+    String eventId = "HD_240808_001"; // 이벤트 ID
 
     @BeforeEach
     void setUp() {
@@ -47,6 +48,7 @@ class RedisSetFcfsServiceLoadTest {
         booleanRedisTemplate.opsForValue().set(FcfsUtil.endFlagFormatting(eventSequence.toString()), false);
         numberRedisTemplate.opsForValue().set(FcfsUtil.keyFormatting(eventSequence.toString()), numberOfWinners);
         stringRedisTemplate.opsForValue().set(FcfsUtil.startTimeFormatting(eventSequence.toString()), "2021-08-01T00:00:00");
+        stringRedisTemplate.opsForValue().set(eventId, eventSequence.toString());
     }
 
     @AfterEach
@@ -70,7 +72,7 @@ class RedisSetFcfsServiceLoadTest {
             final int index = i;
             executorService.execute(() -> {
                 try {
-                    boolean result = redisSetFcfsService.participate(1L, "user" + index);
+                    boolean result = redisSetFcfsService.participate(eventId, "user" + index);
                 } catch (Exception e) {
                     e.printStackTrace();
                 } finally {


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #101 

# 📝 작업 내용

> 선착순 이벤트를 날짜별 하나만 실행한다는 현 정책을 근거로 하여, eventSequence가 아닌 eventId 기반으로 선착순 이벤트 API를 재설계했습니다.
> 이를 통해 선착순 이벤트 엔티티의 PK인 eventSequence을 은닉할 수 있게 되었습니다.
> 한편, 로드밸런싱이 예정되어 있는 만큼, 스케줄링 관련 메서드가 분산 환경으로 확장되는 경우 여러 번 실행되어 의도치 않은 결과가 나타나지 않도록, Redisson 기반 분산 락을 활용하여 오직 하나의 인스턴스만 해당 메서드를 실행하도록 설정했습니다.

- [x] 선착순 이벤트 관련 Controller 개편
- [x] 선착순 이벤트 관련 Service 개편
- [x] 기존 테스트코드 반영
- [x] Scheduler 메서드에 분산환경 대비 분산락 도입
- [x] 로컬에서 기능 검증

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
