### PR TITLE
[feat] 추첨 이벤트 생성 및 수정 시 검증 기능 추가(#106)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum ErrorCode {
-
     // 400 Bad Request
     BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
     INVALID_COMMENT(HttpStatus.BAD_REQUEST, false, "부정적인 표현을 사용하였습니다."),
@@ -19,7 +18,9 @@ public enum ErrorCode {
     INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, false, "이벤트 타입이 지원되지 않습니다."),
     EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, false, "이벤트가 아직 종료되지 않았습니다."),
     EVENT_IS_DRAWING(HttpStatus.BAD_REQUEST, false, "현재 추첨이 진행되고 있는 이벤트입니다."),
-
+    DUPLICATED_POLICIES(HttpStatus.BAD_REQUEST,false,"정책에서 중복된 액션이 존재합니다."),
+    DUPLICATED_GRADES(HttpStatus.BAD_REQUEST,false,"추첨 이벤트 정보에 중복된 등수가 존재합니다."),
+    CANNOT_PARTICIPATE(HttpStatus.BAD_REQUEST,false,"현재 유저가 참여할 수 없는 이벤트입니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, false, "인증되지 않은 사용자입니다."),

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventMetadataDto.java
@@ -1,7 +1,8 @@
 package hyundai.softeer.orange.event.dto.draw;
 
-import hyundai.softeer.orange.event.dto.group.EventEditGroup;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 /**
@@ -21,17 +22,19 @@ public class DrawEventMetadataDto {
      * 추첨 이벤트 등수
      */
     @NotNull
+    @Positive
     private Long grade;
 
     /**
      * 현재 등수에 대한 최대 당첨 인원 수
      */
     @NotNull
+    @Positive
     private Long count;
 
     /**
      * 상품 정보를 기입하는 영역
      */
-    @NotNull
+    @NotBlank
     private String prizeInfo;
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/draw/DrawEventScorePolicyDto.java
@@ -4,6 +4,7 @@ import hyundai.softeer.orange.event.draw.enums.DrawEventAction;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.*;
 
 /**
@@ -29,5 +30,6 @@ public class DrawEventScorePolicyDto {
      * action 1회 수행 시 증가하는 점수
      */
     @NotNull
+    @Positive
     private Integer score;
 }

--- a/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
@@ -3,6 +3,7 @@ package hyundai.softeer.orange.event.dto.fcfs;
 import hyundai.softeer.orange.event.dto.validator.FcfsEventDtoTimeValidation;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +41,7 @@ public class FcfsEventDto {
      * 당첨 인원
      */
     @NotNull
+    @Positive
     private Long participantCount;
 
     /**


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #106

# 📝 작업 내용

1. 추첨 이벤트 중복 정책 / 중복 등수 검증 시스템 구현
2. 전반적인 검증 규칙 조정
