### PR TITLE
[fix] 추첨 이벤트 참여 대상이 아닌 이벤트 유저가 참여할 수 있는 문제 수정(#107)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/core/auth/AuthInterceptor.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/AuthInterceptor.java
@@ -32,7 +32,6 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         Auth classAnnotation = handlerMethod.getBeanType().getAnnotation(Auth.class);
         Auth methodAnnotation = handlerMethod.getMethod().getAnnotation(Auth.class);
-        log.info("annotation {} {}", methodAnnotation, classAnnotation);
 
         // 인증 필요한지 검사. 어노테이션 없으면 인증 필요 없음
         if (classAnnotation == null && methodAnnotation == null) return true;

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -77,6 +77,10 @@ public class EventMetadata {
     @JoinColumn(name="event_frame_id")
     private EventFrame eventFrame;
 
+    // eventFrame을 거치지 않고 유저를 확인하기 위해 사용
+    @Column(name = "event_frame_id", updatable = false, insertable = false)
+    private Long eventFrameId;
+
     // 원래는 one-to-one 관계이지만, JPA 동작에 의해 강제로 EAGER FETCH로 처리돰 -> one-to-many 로 관리
     @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
     private final List<DrawEvent> drawEventList = new ArrayList<>();

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
@@ -76,9 +76,12 @@ public class EventParticipationService {
         if(event.getEventType() != EventType.draw) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
 
         DrawEvent drawEvent = event.getDrawEvent();
+        if(drawEvent == null) throw new EventException(ErrorCode.EVENT_NOT_FOUND);
 
         EventUser eventUser = eventUserRepository.findByUserId(eventUserId)
                 .orElseThrow(() -> new EventUserException(ErrorCode.USER_NOT_FOUND));
+
+        if(!eventUser.getEventFrameId().equals(event.getEventFrameId())) throw new EventException(ErrorCode.CANNOT_PARTICIPATE);
 
         LocalDate today = date.toLocalDate();
 

--- a/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/entity/EventUser.java
@@ -38,6 +38,10 @@ public class EventUser {
     @JoinColumn(name = "event_frame_id")
     private EventFrame eventFrame;
 
+    // eventFrame을 거치지 않고 이벤트를 매칭하기 위해 사용
+    @Column(name = "event_frame_id", updatable = false, insertable = false)
+    private Long eventFrameId;
+
     @OneToMany(mappedBy = "eventUser")
     private List<Comment> commentList = new ArrayList<>();
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #107

# 📝 작업 내용

이벤트 유저가 자신이 속하지 않은 이벤트 프레임의 추첨 이벤트에 접근하지 못하도록 제한하는 조건을 추가했습니다. 이벤트 유저와 이벤트는 모두 db 수준에서 이벤트 프레임에 대한 외래키를 가지고 있으므로, 이벤트 프레임을 fetch하지 않더라도 외래키 비교를 통해 두 객체가 동일한 이벤트 프레임에 속하는지 비교할 수 있습니다. 

불필요한 db 접근을 줄이기 위해 이벤트 프레임 엔티티를 각각 fetch하는 대신 외래키를 노출하여 비교하는 방식으로 문제를 처리했습니다.