### PR TITLE
[refactor, feat] 이벤트 정보가 프레임을 포함하여 반환하도록 수정 외(#110)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventUserController.java
@@ -1,0 +1,46 @@
+package hyundai.softeer.orange.admin.controller;
+
+import hyundai.softeer.orange.core.auth.Auth;
+import hyundai.softeer.orange.core.auth.AuthRole;
+import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
+import hyundai.softeer.orange.eventuser.dto.EventUserPageDto;
+import hyundai.softeer.orange.eventuser.service.EventUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name="admin event user", description = "어드민 페이지에서 이벤트 유저 정보 조회에 사용하는 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/event-users")
+@RestController
+@AdminAuthRequirement @Auth({AuthRole.admin})
+public class AdminEventUserController {
+    private final EventUserService eventUserService;
+
+    /**
+     * @param search 이벤트 유저 이름 검색어
+     * @param page 현재 페이지
+     * @param size 한 페이지의 크기
+     */
+    @Operation(summary = "이벤트 유저 목록을 검색한다", description="이벤트 유저 목록을 검색한다. 이름을 기준으로 검색할 수 있으며, 페이지 / 사이즈가 존재한다.", responses = {
+            @ApiResponse(responseCode = "200", description = "매칭되는 이벤트 유저 리스트를 반환한다."),
+    })
+    @GetMapping
+    public ResponseEntity<EventUserPageDto> getEventUsers(
+            @RequestParam(name="search", required = false, defaultValue = "") String search,
+            @RequestParam(name="page", required = false, defaultValue = "0") @Min(0) Integer page,
+            @RequestParam(name="size", required = false, defaultValue = "10") @Min(1) Integer size
+    ) {
+        var userPageDto = eventUserService.getUserBySearch(search, page, size);
+        return ResponseEntity.ok(userPageDto);
+    }
+
+}

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
@@ -3,6 +3,8 @@ package hyundai.softeer.orange.event.common.repository;
 import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +12,7 @@ import java.util.Optional;
 @Repository
 public interface EventMetadataRepository extends JpaRepository<EventMetadata, Long>, JpaSpecificationExecutor<EventMetadata> {
     Optional<EventMetadata> findFirstByEventId(String eventId);
+
+    @Query("SELECT e from EventMetadata e join fetch e.eventFrame WHERE e.eventId = :eventId")
+    Optional<EventMetadata> findByEventIdWithEventFrame(@Param("eventId") String eventId);
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -153,7 +153,7 @@ public class EventService {
      */
     @Transactional(readOnly = true)
     public EventDto getEventInfo(String eventId) {
-        Optional<EventMetadata> metadataOpt = emRepository.findFirstByEventId(eventId);
+        Optional<EventMetadata> metadataOpt = emRepository.findByEventIdWithEventFrame(eventId);
         EventMetadata metadata = metadataOpt
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
 
@@ -168,6 +168,7 @@ public class EventService {
                 .startTime(metadata.getStartTime())
                 .endTime(metadata.getEndTime())
                 .eventType(metadata.getEventType())
+                .eventFrameId(metadata.getEventFrame().getFrameId())
                 .build();
 
         mapper.fetchToDto(metadata, eventDto);

--- a/src/main/java/hyundai/softeer/orange/eventuser/dto/EventUserOnAdminDto.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/dto/EventUserOnAdminDto.java
@@ -1,0 +1,19 @@
+package hyundai.softeer.orange.eventuser.dto;
+
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import lombok.Getter;
+
+@Getter
+public class EventUserOnAdminDto {
+    private String userName;
+    private String phoneNumber;
+    private String frameId;
+
+    public static EventUserOnAdminDto from(EventUser eventUser) {
+        EventUserOnAdminDto dto = new EventUserOnAdminDto();
+        dto.userName = eventUser.getUserName();
+        dto.phoneNumber = eventUser.getPhoneNumber();
+        dto.frameId = eventUser.getEventFrame().getFrameId();
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/eventuser/dto/EventUserPageDto.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/dto/EventUserPageDto.java
@@ -1,0 +1,24 @@
+package hyundai.softeer.orange.eventuser.dto;
+
+import hyundai.softeer.orange.eventuser.entity.EventUser;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class EventUserPageDto {
+    private List<EventUserOnAdminDto> users;
+    private int totalPage;
+    private int number;
+    private int size;
+
+    public static EventUserPageDto from(Page<EventUser> userPage) {
+        EventUserPageDto dto = new EventUserPageDto();
+        dto.users = userPage.getContent().stream().map(EventUserOnAdminDto::from).toList();
+        dto.totalPage = userPage.getTotalPages();
+        dto.number = userPage.getNumber();
+        dto.size = userPage.getSize();
+        return dto;
+    }
+}

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -2,6 +2,8 @@ package hyundai.softeer.orange.eventuser.repository;
 
 import hyundai.softeer.orange.eventuser.dto.EventUserScoreDto;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +21,9 @@ public interface EventUserRepository extends JpaRepository<EventUser, Long>, Cus
 
     @Query("SELECT eu FROM EventUser eu WHERE eu.userId IN :userIds")
     List<EventUser> findAllByUserId(@Param("userIds") List<String> userIds);
+
+    @Query("SELECT eu FROM EventUser eu join fetch eu.eventFrame WHERE eu.userName LIKE %:search%")
+    Page<EventUser> findBySearch(@Param("search") String search, Pageable pageable);
 
     boolean existsByPhoneNumber(String phoneNumber);
 

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
@@ -8,6 +8,8 @@ import hyundai.softeer.orange.core.jwt.JWTConst;
 import hyundai.softeer.orange.core.jwt.JWTManager;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
 import hyundai.softeer.orange.event.common.repository.EventFrameRepository;
+import hyundai.softeer.orange.eventuser.dto.EventUserOnAdminDto;
+import hyundai.softeer.orange.eventuser.dto.EventUserPageDto;
 import hyundai.softeer.orange.eventuser.dto.RequestAuthCodeDto;
 import hyundai.softeer.orange.eventuser.dto.RequestUserDto;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
@@ -16,6 +18,9 @@ import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +50,14 @@ public class EventUserService {
 
         log.info("EventUser {} found, Login success", eventUser.getUserName());
         return generateToken(eventUser);
+    }
+
+    @Transactional(readOnly = true)
+    public EventUserPageDto getUserBySearch(String search, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        Page<EventUser> userPage = eventUserRepository.findBySearch(search, pageRequest);
+        return EventUserPageDto.from(userPage);
     }
 
     /**


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #110

# 📝 작업 내용
프론트엔드 측의 요구사항을 반영하고, 추가적으로 요구된 "이벤트 유저 조회" 기능을 구현했습니다.

1. 이벤트 상세 조회 시 이벤트 프레임 정보를 함께 반환하도록 수정
2. 이벤트 유저 페이지 기반 조회 기능 구현
