### PR TITLE
[refactor] Auth 어노테이션이 메타 어노테이션인 경우에도 대응할 수 있도록 변경(#112)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminCommentController.java
@@ -2,9 +2,7 @@ package hyundai.softeer.orange.admin.controller;
 import hyundai.softeer.orange.comment.dto.CommentsPageDto;
 import hyundai.softeer.orange.comment.dto.DeleteCommentsDto;
 import hyundai.softeer.orange.comment.service.CommentService;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.AdminAuth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/admin/comments")
 @RequiredArgsConstructor
 @RestController
-@AdminAuthRequirement @Auth({AuthRole.admin})
+@AdminAuth
 public class AdminCommentController {
     private final CommentService commentService;
 

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminDrawEventController.java
@@ -3,9 +3,7 @@ package hyundai.softeer.orange.admin.controller;
 import hyundai.softeer.orange.common.ErrorResponse;
 import hyundai.softeer.orange.event.draw.dto.DrawEventStatusDto;
 import hyundai.softeer.orange.event.draw.dto.ResponseDrawWinnerDto;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.AdminAuth;
 import hyundai.softeer.orange.event.draw.service.DrawEventService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -22,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/draw")
 @RestController
-@AdminAuthRequirement @Auth({AuthRole.admin})
+@AdminAuth
 public class AdminDrawEventController {
     private final DrawEventService drawEventService;
     /**

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -3,9 +3,7 @@ package hyundai.softeer.orange.admin.controller;
 import hyundai.softeer.orange.admin.component.AdminAnnotation;
 import hyundai.softeer.orange.admin.dto.AdminDto;
 import hyundai.softeer.orange.common.ErrorResponse;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.AdminAuth;
 import hyundai.softeer.orange.event.common.service.EventService;
 import hyundai.softeer.orange.event.dto.*;
 import hyundai.softeer.orange.event.dto.group.EventEditGroup;
@@ -30,7 +28,7 @@ import java.util.List;
  */
 @Tag(name = "admin event", description = "어드민 페이지에서 이벤트 관리에 사용하는 api")
 @Slf4j
-@AdminAuthRequirement @Auth({AuthRole.admin})
+@AdminAuth
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/events")
 @RestController

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventUserController.java
@@ -1,12 +1,9 @@
 package hyundai.softeer.orange.admin.controller;
 
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.AdminAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.AdminAuth;
 import hyundai.softeer.orange.eventuser.dto.EventUserPageDto;
 import hyundai.softeer.orange.eventuser.service.EventUserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
@@ -21,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/event-users")
 @RestController
-@AdminAuthRequirement @Auth({AuthRole.admin})
+@AdminAuth
 public class AdminEventUserController {
     private final EventUserService eventUserService;
 

--- a/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
+++ b/src/main/java/hyundai/softeer/orange/comment/controller/CommentController.java
@@ -4,9 +4,7 @@ import hyundai.softeer.orange.comment.dto.CreateCommentDto;
 import hyundai.softeer.orange.comment.dto.ResponseCommentsDto;
 import hyundai.softeer.orange.comment.service.CommentService;
 import hyundai.softeer.orange.common.ErrorResponse;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.EventUserAuth;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
 import hyundai.softeer.orange.eventuser.dto.EventUserInfo;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,7 +25,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/comment")
 @RestController
 public class CommentController {
-
     private final CommentService commentService;
 
     @Tag(name = "Comment")
@@ -40,7 +37,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getComments(eventFrameId));
     }
 
-    @EventUserAuthRequirement @Auth(AuthRole.event_user)
+    @EventUserAuth
     @Tag(name = "Comment")
     @PostMapping("/{eventFrameId}")
     @Operation(summary = "기대평 등록", description = "유저가 신규 기대평을 등록한다.", responses = {
@@ -57,7 +54,7 @@ public class CommentController {
         return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto));
     }
 
-    @EventUserAuthRequirement @Auth(AuthRole.event_user)
+    @EventUserAuth
     @Tag(name = "Comment")
     @GetMapping("/info")
     @Operation(summary = "기대평 등록 가능 여부 조회", description = "오늘 기대평 등록 가능 여부를 조회한다.", responses = {

--- a/src/main/java/hyundai/softeer/orange/core/auth/list/AdminAuth.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/list/AdminAuth.java
@@ -1,6 +1,8 @@
 package hyundai.softeer.orange.core.auth.list;
 
+import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthConst;
+import hyundai.softeer.orange.core.auth.AuthRole;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.lang.annotation.*;
@@ -8,6 +10,7 @@ import java.lang.annotation.*;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@SecurityRequirement(name = AuthConst.EVENT_USER_AUTH)
-public @interface EventUserAuthRequirement {
+@SecurityRequirement(name = AuthConst.ADMIN_AUTH)
+@Auth({AuthRole.admin})
+public @interface AdminAuth {
 }

--- a/src/main/java/hyundai/softeer/orange/core/auth/list/EventUserAuth.java
+++ b/src/main/java/hyundai/softeer/orange/core/auth/list/EventUserAuth.java
@@ -1,6 +1,8 @@
 package hyundai.softeer.orange.core.auth.list;
 
+import hyundai.softeer.orange.core.auth.Auth;
 import hyundai.softeer.orange.core.auth.AuthConst;
+import hyundai.softeer.orange.core.auth.AuthRole;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 import java.lang.annotation.*;
@@ -8,6 +10,7 @@ import java.lang.annotation.*;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@SecurityRequirement(name = AuthConst.ADMIN_AUTH)
-public @interface AdminAuthRequirement {
+@SecurityRequirement(name = AuthConst.EVENT_USER_AUTH)
+@Auth({AuthRole.event_user})
+public @interface EventUserAuth {
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/controller/DrawEventController.java
@@ -1,9 +1,7 @@
 package hyundai.softeer.orange.event.draw.controller;
 
 import hyundai.softeer.orange.common.ErrorResponse;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.EventUserAuth;
 import hyundai.softeer.orange.event.draw.dto.EventParticipationDatesDto;
 import hyundai.softeer.orange.event.draw.service.EventParticipationService;
 import hyundai.softeer.orange.eventuser.component.EventUserAnnotation;
@@ -22,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/event/draw")
 @RestController
-@EventUserAuthRequirement @Auth({AuthRole.event_user})
+@EventUserAuth
 public class DrawEventController {
     private final EventParticipationService epService;
     /**

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -1,9 +1,7 @@
 package hyundai.softeer.orange.event.fcfs.controller;
 
 import hyundai.softeer.orange.common.ErrorResponse;
-import hyundai.softeer.orange.core.auth.Auth;
-import hyundai.softeer.orange.core.auth.AuthRole;
-import hyundai.softeer.orange.core.auth.list.EventUserAuthRequirement;
+import hyundai.softeer.orange.core.auth.list.EventUserAuth;
 import hyundai.softeer.orange.event.fcfs.dto.RequestAnswerDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsInfoDto;
 import hyundai.softeer.orange.event.fcfs.dto.ResponseFcfsResultDto;
@@ -32,7 +30,7 @@ public class FcfsController {
     private final FcfsAnswerService fcfsAnswerService;
     private final FcfsManageService fcfsManageService;
 
-    @EventUserAuthRequirement @Auth(AuthRole.event_user)
+    @EventUserAuth
     @PostMapping("/{eventId}")
     @Operation(summary = "선착순 이벤트 참여", description = "선착순 이벤트에 참여한 결과(boolean)를 반환한다.", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트 당첨 성공 혹은 실패",
@@ -57,7 +55,7 @@ public class FcfsController {
         return ResponseEntity.ok(fcfsManageService.getFcfsInfo(eventId));
     }
 
-    @EventUserAuthRequirement @Auth(AuthRole.event_user)
+    @EventUserAuth
     @GetMapping("/{eventId}/participated")
     @Operation(summary = "선착순 이벤트 참여 여부 조회", description = "정답을 맞혀서 선착순 이벤트에 참여했는지 여부를 조회한다. (당첨은 별도)", responses = {
             @ApiResponse(responseCode = "200", description = "선착순 이벤트의 정답을 맞혀서 참여했는지에 대한 결과",


### PR DESCRIPTION
# #️⃣ 연관 이슈

> ex) #112

# 📝 작업 내용

> AnnotationUtils 기반으로 Auth 어노테이션 탐색 방식을 변경하여 Auth가 다른 어노테이션에 등록된 상태로 api에 연결되더라도 정상적으로 인증을 요구하도록 개선했습니다. 또한 인증용 어노테이션, swagger 인증 문서화용 어노테이션을 따로 api에 붙이는 대신 둘을 하나의 어노테이션에 등록하여 사용할 수 있게 하여 오류의 소지를 줄였습니다.

```java
@EventUserAuth
    public ResponseEntity<Boolean> createComment(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventFrameId, @RequestBody @Valid CreateCommentDto dto) {
        return ResponseEntity.ok(commentService.createComment(userInfo.getUserId(), eventFrameId, dto));
    }
```
Auth, SecurityRequirement를 더 이상 따로 등록할 필요 없이 EventAuth 어노테이션 하나로 처리가 가능해졌습니다.