### PR TITLE
[fix] 배포 환경에서 로그 수집이 멈추고 도커 이미지가 누적되는 버그 수정 (#118)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -47,3 +47,4 @@ jobs:
           sudo docker-compose --env-file ../.env down
           sudo docker-compose --env-file ../.env up -d
           rm -f ../.env
+          sudo docker image prune -f

--- a/infra/promtail-config.yml
+++ b/infra/promtail-config.yml
@@ -14,4 +14,5 @@ scrape_configs:
         - localhost
         labels:
           job: springboot
+          host: ${HOSTNAME} # hostname을 통해 로그 모니터링 시 각 인스턴스 식별
           __path__: /var/log/spring-boot/*.log

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,4 +1,6 @@
 <configuration>
+    <property name="LOG_DIR" value="/var/log/spring-boot" />
+
     <!-- 콘솔 출력 설정 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -22,8 +24,6 @@
 
     <!-- 개발 환경 -->
     <springProfile name="(default|local)">
-        <property name="LOG_DIR" value="/var/log/spring-boot" />
-
         <!-- 루트 로거 설정: 콘솔 및 일반 파일에 로그 저장 -->
         <root level="info">
             <appender-ref ref="CONSOLE"/>
@@ -33,8 +33,6 @@
 
     <!-- 배포 환경 -->
     <springProfile name="prod">
-        <property name="LOG_DIR" value="logs" />
-        <!-- test 환경에서는 로그를 콘솔에만 출력 -->
         <root level="info">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #118

# 📝 작업 내용

- [x] prod 환경에서 로그 수집이 멈추는 버그 수정
- [x] 도커 이미지가 누적되어 서버에 부담이 생기는 문제 해결을 위해 배포 완료 시 old image 삭제
- [x] promtail 로그 수집 및 전송 시 labeling을 통해 모니터링 환경에서 로그의 출처 노드를 구분할 수 있도록 함

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
