### PR TITLE
[fix] 선착순 이벤트 정보 찾을 수 없던 버그 수정 (#122)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -115,6 +115,7 @@ public class FcfsManageService {
     public Boolean isParticipated(String eventId, String userId) {
         String key = getFcfsKeyFromEventId(eventId);
         if(!fcfsEventRepository.existsById(Long.parseLong(key))) {
+            log.error("eventId {} 에 해당되는 선착순 이벤트를 DB에서 찾을 수 없음", eventId);
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
         return Boolean.TRUE.equals(stringRedisTemplate.opsForSet().isMember(FcfsUtil.participantFormatting(key), userId));
@@ -160,6 +161,7 @@ public class FcfsManageService {
 
     private LocalDateTime getTimeFromScore(Double score) {
         if(score == null) {
+            log.error("score 값이 null");
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
         long timeMillis = score.longValue();
@@ -167,8 +169,9 @@ public class FcfsManageService {
     }
 
     private String getFcfsKeyFromEventId(String eventId) {
-        String key = stringRedisTemplate.opsForValue().get(eventId);
+        String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
+            log.error("eventId {} 에 해당되는 key를 Redis 상에서 찾을 수 없음", eventId);
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
         return key;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -29,6 +29,7 @@ public class RedisLuaFcfsService implements FcfsService {
     public boolean participate(String eventId, String userId) {
         String key = stringRedisTemplate.opsForValue().get(FcfsUtil.eventIdFormatting(eventId));
         if(key == null) {
+            log.error("eventId {} 에 해당되는 key를 Redis 상에서 찾을 수 없음", eventId);
             throw new FcfsEventException(ErrorCode.EVENT_NOT_FOUND);
         }
         Long eventSequence = Long.parseLong(key);
@@ -47,6 +48,7 @@ public class RedisLuaFcfsService implements FcfsService {
         // 잘못된 이벤트 참여 시간
         String startTime = stringRedisTemplate.opsForValue().get(FcfsUtil.startTimeFormatting(key));
         if(startTime == null) {
+            log.error("eventId {}의 시작시간을 Redis 상에서 찾을 수 없음", eventId);
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
 

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
@@ -74,7 +74,7 @@ class FcfsManageServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(eventId)).willReturn(fcfsEventId.toString());
+        given(valueOperations.get(FcfsUtil.eventIdFormatting(eventId))).willReturn(fcfsEventId.toString());
     }
 
     @DisplayName("registerFcfsEvents: 오늘의 선착순 이벤트 정보(당첨자 수, 시작 시각)를 배치")


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #122

# 📝 작업 내용

> 선착순 이벤트 조회 및 참여 기능에 에러가 있어 신속하게 수정했습니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항