### PR TITLE
[fix] LocalDateTime에 의한 타임존 문제 해결(#115)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
+++ b/src/main/java/hyundai/softeer/orange/comment/dto/ResponseCommentDto.java
@@ -1,12 +1,11 @@
 package hyundai.softeer.orange.comment.dto;
 
 import hyundai.softeer.orange.comment.entity.Comment;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @NoArgsConstructor
 @Builder
@@ -16,10 +15,10 @@ public class ResponseCommentDto {
     private Long id;
     private String content;
     private String userName;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     // CommentRepository에서 Projection으로 ResponseCommentDto를 생성할 때 사용, 추후 더 나은 방법으로 수정 필요
-    public ResponseCommentDto(Long id, String content, String userName, LocalDateTime createdAt) {
+    public ResponseCommentDto(Long id, String content, String userName, Instant createdAt) {
         this.id = id;
         this.content = content;
         this.userName = userName;

--- a/src/main/java/hyundai/softeer/orange/comment/entity/Comment.java
+++ b/src/main/java/hyundai/softeer/orange/comment/entity/Comment.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Table(name="comment")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,7 +25,7 @@ public class Comment {
     private String content;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_frame_id")
@@ -43,7 +43,6 @@ public class Comment {
         comment.content = content;
         comment.eventFrame = eventFrame;
         comment.eventUser = eventUser;
-//        comment.createdAt = LocalDateTime.now(); // FIXME: 현재 테스트 시 자동 생성되지 않고 있음
         comment.isPositive = isPositive;
         return comment;
     }

--- a/src/main/java/hyundai/softeer/orange/comment/entity/Comment.java
+++ b/src/main/java/hyundai/softeer/orange/comment/entity/Comment.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -41,7 +43,7 @@ public class Comment {
         comment.content = content;
         comment.eventFrame = eventFrame;
         comment.eventUser = eventUser;
-        comment.createdAt = LocalDateTime.now(); // FIXME: 현재 테스트 시 자동 생성되지 않고 있음
+//        comment.createdAt = LocalDateTime.now(); // FIXME: 현재 테스트 시 자동 생성되지 않고 있음
         comment.isPositive = isPositive;
         return comment;
     }

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -62,8 +62,8 @@ public class CommentService {
 
         // 오늘의 시작과 끝 시각 계산
         LocalDate today = LocalDate.now();
-        Instant startOfDay = today.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant();
-        Instant endOfDay = today.atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant();
+        Instant startOfDay = today.atStartOfDay().atZone(ZoneOffset.systemDefault()).toInstant();
+        Instant endOfDay = today.atTime(LocalTime.MAX).atZone(ZoneOffset.systemDefault()).toInstant();
 
         // 오늘 유저가 인터렉션에 참여하지 않았다면 예외처리
         boolean participated = participationInfoRepository.existsByEventUserAndDrawEventAndDateBetween(eventUser, drawEvent, startOfDay, endOfDay);

--- a/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
+++ b/src/main/java/hyundai/softeer/orange/comment/service/CommentService.java
@@ -27,9 +27,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -64,8 +62,8 @@ public class CommentService {
 
         // 오늘의 시작과 끝 시각 계산
         LocalDate today = LocalDate.now();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime endOfDay = today.atTime(LocalTime.MAX);
+        Instant startOfDay = today.atStartOfDay().atZone(ZoneId.systemDefault()).toInstant();
+        Instant endOfDay = today.atTime(LocalTime.MAX).atZone(ZoneId.systemDefault()).toInstant();
 
         // 오늘 유저가 인터렉션에 참여하지 않았다면 예외처리
         boolean participated = participationInfoRepository.existsByEventUserAndDrawEventAndDateBetween(eventUser, drawEvent, startOfDay, endOfDay);
@@ -77,7 +75,6 @@ public class CommentService {
         }
 
         boolean isPositive = commentValidator.analyzeComment(dto.getContent());
-
         Comment comment = Comment.of(dto.getContent(), eventFrame, eventUser, isPositive);
         commentRepository.save(comment);
         log.info("created comment: {}", comment.getId());

--- a/src/main/java/hyundai/softeer/orange/common/util/DateUtil.java
+++ b/src/main/java/hyundai/softeer/orange/common/util/DateUtil.java
@@ -2,12 +2,12 @@ package hyundai.softeer.orange.common.util;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Date;
 
 public class DateUtil {
     public static Date localDateTimeToDate(LocalDateTime localDateTime) {
-        Instant instant = localDateTime.atZone(ZoneId.systemDefault()).toInstant();
+        Instant instant = localDateTime.atZone(ZoneOffset.systemDefault()).toInstant();
 
         return Date.from(instant);
     }

--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapper.java
@@ -11,7 +11,7 @@ import hyundai.softeer.orange.event.fcfs.repository.FcfsEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -50,7 +50,7 @@ public class FcfsEventFieldMapper implements EventFieldMapper {
     /**
      * 이벤트의 시간을 검증하는 함수
      */
-    protected void validateEventTimes(List<FcfsEventDto> dtos, LocalDateTime startTime, LocalDateTime endTime) {
+    protected void validateEventTimes(List<FcfsEventDto> dtos, Instant startTime, Instant endTime) {
         // 비어 있으면 안됨
         if (dtos == null || dtos.isEmpty()) throw new EventException(ErrorCode.INVALID_JSON);
         // 시작 순서대로 정렬
@@ -64,8 +64,8 @@ public class FcfsEventFieldMapper implements EventFieldMapper {
 
         // 시작 시간으로 정렬했으므로, 다음 시간대와 겹치지 않는다면 이후 시간대와는 절대 겹치지 않는다. O(N)
         for(int idx = 0; idx < dtos.size() - 1; idx++) {
-            LocalDateTime nowEnd = dtos.get(idx).getEndTime();
-            LocalDateTime nextStart = dtos.get(idx + 1).getStartTime();
+            Instant nowEnd = dtos.get(idx).getEndTime();
+            Instant nextStart = dtos.get(idx + 1).getStartTime();
 
             if(nowEnd.isAfter(nextStart)) throw new EventException(ErrorCode.INVALID_INPUT_EVENT_TIME);
         }

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,10 +35,10 @@ public class EventMetadata {
     private String description;
 
     @Column
-    private LocalDateTime startTime;
+    private Instant startTime;
 
     @Column
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     @Column
     private EventType eventType;
@@ -57,11 +57,11 @@ public class EventMetadata {
         this.description = description;
     }
 
-    public void updateStartTime(LocalDateTime startTime) {
+    public void updateStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
-    public void updateEndTime(LocalDateTime endTime) {
+    public void updateEndTime(Instant endTime) {
         this.endTime = endTime;
     }
 
@@ -69,7 +69,7 @@ public class EventMetadata {
         this.url = url;
     }
 
-    public boolean isEnded(LocalDateTime now) {
+    public boolean isEnded(Instant now) {
         return (this.status == EventStatus.COMPLETE) || endTime.isBefore(now);
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/component/EventKeyGenerator.java
+++ b/src/main/java/hyundai/softeer/orange/event/component/EventKeyGenerator.java
@@ -5,8 +5,10 @@ import hyundai.softeer.orange.event.common.EventConst;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class EventKeyGenerator {
@@ -23,7 +25,8 @@ public class EventKeyGenerator {
     }
 
     public String generate(LocalDateTime now) {
-        LocalDateTime nextDay = now.plusDays(1).toLocalDate().atTime(0,0,5);
+        // UTC 기준으로 시차는 -12 ~ 12시간, 키가 48시간 유지되면 모든 지역에서 "오늘"의 키 사용 가능. 여유 시간 10초
+        LocalDateTime diffDay = now.plusDays(2).toLocalDate().atTime(0,0,10);
 
         String dateInfo = formatter.format(now);
         String incKey = EventConst.REDIS_KEY_PREFIX + dateInfo;
@@ -31,7 +34,7 @@ public class EventKeyGenerator {
         Long number = redisTemplate.opsForValue().increment(incKey);
 
         if(number != null && number == 1)
-            redisTemplate.expireAt(incKey, DateUtil.localDateTimeToDate(nextDay));
+            redisTemplate.expireAt(incKey, DateUtil.localDateTimeToDate(diffDay));
 
         return String.format("HD_%s_%03d", dateInfo, number);
     }

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDateDto.java
@@ -1,7 +1,7 @@
 package hyundai.softeer.orange.event.draw.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public interface EventParticipationDateDto{
-    LocalDateTime getDate();
+    Instant getDate();
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDatesDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/dto/EventParticipationDatesDto.java
@@ -1,6 +1,6 @@
 package hyundai.softeer.orange.event.draw.dto;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
-public record EventParticipationDatesDto(List<LocalDateTime> dates) {}
+public record EventParticipationDatesDto(List<Instant> dates) {}

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/EventParticipationInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/EventParticipationInfo.java
@@ -4,7 +4,7 @@ import hyundai.softeer.orange.eventuser.entity.EventUser;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Table(name="event_participation_info")
 @Getter
@@ -15,7 +15,7 @@ public class EventParticipationInfo {
     private Long id;
 
     @Column
-    private LocalDateTime date;
+    private Instant date;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="event_user_id")
@@ -25,7 +25,7 @@ public class EventParticipationInfo {
     @JoinColumn(name="draw_event_id")
     private DrawEvent drawEvent;
 
-    public static EventParticipationInfo of(LocalDateTime date, EventUser eventUser, DrawEvent drawEvent) {
+    public static EventParticipationInfo of(Instant date, EventUser eventUser, DrawEvent drawEvent) {
         EventParticipationInfo participationInfo = new EventParticipationInfo();
         participationInfo.date = date;
         participationInfo.eventUser = eventUser;

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/EventParticipationInfoRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -27,5 +27,5 @@ public interface EventParticipationInfoRepository extends JpaRepository<EventPar
             "AND info.draw_event_id = :drawEventId", nativeQuery = true)
     List<EventParticipationDateDto> findByEventUserId(@Param("eventUserId") String eventUserId, @Param("drawEventId") Long drawEventId);
 
-    boolean existsByEventUserAndDrawEventAndDateBetween(EventUser eventUser, DrawEvent drawEvent, @Param("from") LocalDateTime from, @Param("to") LocalDateTime to);
+    boolean existsByEventUserAndDrawEventAndDateBetween(EventUser eventUser, DrawEvent drawEvent, @Param("from") Instant from, @Param("to") Instant to);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -48,7 +48,7 @@ public class DrawEventService {
         DrawEvent drawEvent = event.getDrawEvent();
         if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
         // 이벤트 검증
-        validateDrawCondition(event, LocalDateTime.now());
+        validateDrawCondition(event, Instant.now());
         String key = EventConst.IS_DRAWING(event.getEventId());
         tryDraw(key);
 
@@ -96,7 +96,7 @@ public class DrawEventService {
         redisTemplate.delete(key);
     }
 
-    private void validateDrawCondition(EventMetadata event, LocalDateTime now) {
+    private void validateDrawCondition(EventMetadata event, Instant now) {
         // 이벤트가 draw event 인지 검사
         if (event.getEventType() != EventType.draw) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
         // 이벤트가 종료되었는지 검사
@@ -125,7 +125,7 @@ public class DrawEventService {
 
         DrawEventStatus status = DrawEventStatus.AVAILABLE;
 
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = Instant.now();
 
         // 이벤트가 종료되었는지 검사
         if (!event.isEnded(now)) status = DrawEventStatus.BEFORE_END;

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/EventParticipationService.java
@@ -81,7 +81,8 @@ public class EventParticipationService {
 
         if(!eventUser.getEventFrameId().equals(event.getEventFrameId())) throw new EventException(ErrorCode.CANNOT_PARTICIPATE);
 
-        LocalDate today = LocalDate.ofInstant(date, ZoneId.systemDefault());
+        // TODO: 이벤트 정보를 저장할 때 타임존을 함께 저장하도록 변경. 현재는 서버 배포 환경 시간을 기반으로 동작하도록 설정
+        LocalDate today = LocalDate.ofInstant(date, ZoneOffset.systemDefault());
 
         // 이벤트 기간 안에 있는지 검사
         if(event.getStartTime().isAfter(date) || event.getEndTime().isBefore(date))

--- a/src/main/java/hyundai/softeer/orange/event/dto/BriefEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/BriefEventDto.java
@@ -1,9 +1,8 @@
 package hyundai.softeer.orange.event.dto;
 
 import hyundai.softeer.orange.event.common.enums.EventType;
-import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * 이벤트 리스트를 위한 정보만 담고 있는 객체
@@ -21,12 +20,12 @@ public interface BriefEventDto {
     /**
      * 이벤트 시작 시간
      */
-    LocalDateTime getStartTime();
+    Instant getStartTime();
 
     /**
      * 이벤트 종료 시간
      */
-    LocalDateTime getEndTime();
+    Instant getEndTime();
 
     /**
      * 이벤트의 타입

--- a/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/EventDto.java
@@ -11,7 +11,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -47,13 +47,13 @@ public class EventDto {
      * 이벤트 시작 시간
      */
     @NotNull
-    private LocalDateTime startTime;
+    private Instant startTime;
 
     /**
      * 이벤트 종료 시간
      */
     @NotNull
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     /**
      * 이벤트 페이지의 url

--- a/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/fcfs/FcfsEventDto.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * 선착순 이벤트를 표현하는 객체
@@ -29,13 +29,13 @@ public class FcfsEventDto {
      * 시작 시간
      */
     @NotNull
-    private LocalDateTime startTime;
+    private Instant startTime;
 
     /**
      * 종료 시간
      */
     @NotNull
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     /**
      * 당첨 인원

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsInfoDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsInfoDto.java
@@ -4,14 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResponseFcfsInfoDto {
 
-    private LocalDateTime eventStartTime;
+    private Instant eventStartTime;
 
     private String eventStatus;
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/dto/ResponseFcfsWinnerDto.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Builder
 @NoArgsConstructor
@@ -15,5 +15,5 @@ public class ResponseFcfsWinnerDto {
 
     private String name;
     private String phoneNumber;
-    private LocalDateTime winningTime;
+    private Instant winningTime;
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEvent.java
@@ -4,7 +4,7 @@ import hyundai.softeer.orange.event.common.entity.EventMetadata;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,10 +20,10 @@ public class FcfsEvent {
     private Long id;
 
     @Column
-    private LocalDateTime startTime;
+    private Instant startTime;
 
     @Column
-    private LocalDateTime endTime;
+    private Instant endTime;
 
     @Column
     private Long participantCount;
@@ -38,11 +38,11 @@ public class FcfsEvent {
     @OneToMany(mappedBy = "fcfsEvent")
     private final List<FcfsEventWinningInfo> infos = new ArrayList<>();
 
-    public void updateStartTime(LocalDateTime startTime) {
+    public void updateStartTime(Instant startTime) {
         this.startTime = startTime;
     }
 
-    public void updateEndTime(LocalDateTime endTime) {
+    public void updateEndTime(Instant endTime) {
         this.endTime = endTime;
     }
 
@@ -54,7 +54,7 @@ public class FcfsEvent {
         this.prizeInfo = prizeInfo;
     }
 
-    public static FcfsEvent of(LocalDateTime startTime, LocalDateTime endTime, Long participantCount, String prizeInfo, EventMetadata eventMetadata) {
+    public static FcfsEvent of(Instant startTime, Instant endTime, Long participantCount, String prizeInfo, EventMetadata eventMetadata) {
         FcfsEvent fcfsEvent = new FcfsEvent();
         fcfsEvent.startTime = startTime;
         fcfsEvent.endTime = endTime;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/entity/FcfsEventWinningInfo.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Table(name="fcfs_event_winning_info")
 @Getter
@@ -25,9 +25,9 @@ public class FcfsEventWinningInfo {
     @JoinColumn(name ="event_user_id")
     private EventUser eventUser;
 
-    private LocalDateTime winningTime;
+    private Instant winningTime;
 
-    public static FcfsEventWinningInfo of(FcfsEvent fcfsEvent, EventUser eventUser, LocalDateTime winningTime) {
+    public static FcfsEventWinningInfo of(FcfsEvent fcfsEvent, EventUser eventUser, Instant winningTime) {
         FcfsEventWinningInfo fcfsEventWinningInfo = new FcfsEventWinningInfo();
         fcfsEventWinningInfo.fcfsEvent = fcfsEvent;
         fcfsEventWinningInfo.eventUser = eventUser;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/repository/FcfsEventRepository.java
@@ -7,14 +7,14 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FcfsEventRepository extends JpaRepository<FcfsEvent, Long> {
 
-    List<FcfsEvent> findByStartTimeBetween(LocalDateTime startTime, LocalDateTime endTime);
+    List<FcfsEvent> findByStartTimeBetween(Instant startTime, Instant endTime);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select e from FcfsEvent e left join fetch e.infos where e.id = :id")

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/DbFcfsService.java
@@ -16,7 +16,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -49,8 +49,9 @@ public class DbFcfsService implements FcfsService{
         EventUser eventUser = eventUserRepository.findByUserId(userId)
                 .orElseThrow(() -> new FcfsEventException(ErrorCode.EVENT_USER_NOT_FOUND));
 
-        // 잘못된 이벤트 참여 시간인지 검증
-        if(LocalDateTime.now().isBefore(fcfsEvent.getStartTime()) || LocalDateTime.now().isAfter(fcfsEvent.getEndTime())){
+        Instant now = Instant.now();
+        // 잘못된 벤트 참여 시간인지 검증
+        if(now.isBefore(fcfsEvent.getStartTime()) || now.isAfter(fcfsEvent.getEndTime())){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 
@@ -66,7 +67,7 @@ public class DbFcfsService implements FcfsService{
             return false;
         }
 
-        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser, LocalDateTime.now()));
+        fcfsEventWinningInfoRepository.save(FcfsEventWinningInfo.of(fcfsEvent, eventUser, Instant.now()));
         log.info("Participating Success: {}, User ID: {}", eventSequence, userId);
         return true;
     }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsAnswerService.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @RequiredArgsConstructor
 @Service
@@ -27,7 +27,7 @@ public class FcfsAnswerService {
         if(startTime == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
-        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+        if (Instant.now().isBefore(Instant.parse(startTime))){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLockFcfsService.java
@@ -11,7 +11,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -49,7 +49,7 @@ public class RedisLockFcfsService implements FcfsService {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
 
-        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+        if (Instant.now().isBefore(Instant.parse(startTime))){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -12,7 +12,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Collections;
 
 @RequiredArgsConstructor
@@ -52,7 +52,7 @@ public class RedisLuaFcfsService implements FcfsService {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
 
-        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+        if (Instant.now().isBefore(Instant.parse(startTime))){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisSetFcfsService.java
@@ -9,7 +9,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -44,7 +44,7 @@ public class RedisSetFcfsService implements FcfsService {
         if(startTime == null) {
             throw new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND);
         }
-        if (LocalDateTime.now().isBefore(LocalDateTime.parse(startTime))){
+        if (Instant.now().isBefore(Instant.parse(startTime))){
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 

--- a/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/comment/CommentServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -87,7 +88,7 @@ class CommentServiceTest {
                 .id(1L)
                 .content("test")
                 .userName("test")
-                .createdAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now().atZone(ZoneOffset.UTC).toInstant())
                 .build();
         given(commentRepository.findRandomPositiveComments(anyLong(), eq(pageable)))
                 .willReturn(List.of(responseCommentDto));

--- a/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapperTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/FcfsEventFieldMapperTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,19 +62,19 @@ class FcfsEventFieldMapperTest {
     @Test
     void setRelationIfFcfsDtoExists() {
         EventMetadata metadata = new EventMetadata();
-        metadata.updateStartTime(LocalDateTime.of(2024, 8, 1, 0, 0));
-        metadata.updateEndTime(LocalDateTime.of(2024, 8, 2, 0, 0));
+        metadata.updateStartTime(LocalDateTime.of(2024, 8, 1, 0, 0).atZone(ZoneOffset.UTC).toInstant());
+        metadata.updateEndTime(LocalDateTime.of(2024, 8, 2, 0, 0).atZone(ZoneOffset.UTC).toInstant());
         EventDto dto = mock(EventDto.class);
         List<FcfsEventDto> dtos = new ArrayList<>();
 
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,0,0))
-                .endTime(LocalDateTime.of(2024,8,1,4,0))
+                .startTime(LocalDateTime.of(2024,8,1,0,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
                 .build() // 시작 시간 겹침
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,4,0))
-                .endTime(LocalDateTime.of(2024,8,1,8,0))
+                .startTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,8,0).atZone(ZoneOffset.UTC).toInstant())
                 .build() // 시간끼리 겹침
         );
 
@@ -89,22 +91,22 @@ class FcfsEventFieldMapperTest {
     @DisplayName("하나라도 기간 외 이벤트 시간대가 있다면 예외 반환")
     @Test
     void validationEventTimes_throwIfThereIsTimeOverBoundary() {
-        LocalDateTime startTime = LocalDateTime.of(2024, 8, 1, 0, 0);
-        LocalDateTime endTime = LocalDateTime.of(2024, 8, 2, 0, 0);
+        Instant startTime = LocalDateTime.of(2024, 8, 1, 0, 0).atZone(ZoneOffset.UTC).toInstant();
+        Instant endTime = LocalDateTime.of(2024, 8, 2, 0, 0).atZone(ZoneOffset.UTC).toInstant();
         List<FcfsEventDto> dtos = new ArrayList<>();
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,0,0))
-                .endTime(LocalDateTime.of(2024,8,1,4,0))
+                .startTime(LocalDateTime.of(2024,8,1,0,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
                 .build()
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,4,0))
-                .endTime(LocalDateTime.of(2024,8,1,8,0))
+                .startTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,8,0).atZone(ZoneOffset.UTC).toInstant())
                 .build()
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,23,0))
-                .endTime(LocalDateTime.of(2024,8,2,0,1))
+                .startTime(LocalDateTime.of(2024,8,1,23,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,0,1).atZone(ZoneOffset.UTC).toInstant())
                 .build()
         );
 
@@ -117,17 +119,17 @@ class FcfsEventFieldMapperTest {
     @DisplayName("겹치는 시간대가 있다면 예외 반환")
     @Test
     void validationEventTimes_throwIfFcfsHasOverlay() {
-        LocalDateTime startTime = LocalDateTime.of(2024, 8, 1, 0, 0);
-        LocalDateTime endTime = LocalDateTime.of(2024, 8, 2, 0, 0);
+        Instant startTime = LocalDateTime.of(2024, 8, 1, 0, 0).atZone(ZoneOffset.UTC).toInstant();
+        Instant endTime = LocalDateTime.of(2024, 8, 2, 0, 0).atZone(ZoneOffset.UTC).toInstant();
         List<FcfsEventDto> dtos = new ArrayList<>();
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,0,0))
-                .endTime(LocalDateTime.of(2024,8,1,4,0))
+                .startTime(LocalDateTime.of(2024,8,1,0,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
                 .build()
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,3,0))
-                .endTime(LocalDateTime.of(2024,8,1,8,0))
+                .startTime(LocalDateTime.of(2024,8,1,3,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,8,0).atZone(ZoneOffset.UTC).toInstant())
                 .build()
         );
 
@@ -140,22 +142,22 @@ class FcfsEventFieldMapperTest {
     @DisplayName("겹치는 시간대가 없다면 정상적으로 실행")
     @Test
     void validationEventTimes_validateSuccessfully() {
-        LocalDateTime startTime = LocalDateTime.of(2024, 8, 1, 0, 0);
-        LocalDateTime endTime = LocalDateTime.of(2024, 8, 2, 0, 0);
+        Instant startTime = LocalDateTime.of(2024, 8, 1, 0, 0).atZone(ZoneOffset.UTC).toInstant();
+        Instant endTime = LocalDateTime.of(2024, 8, 2, 0, 0).atZone(ZoneOffset.UTC).toInstant();
         List<FcfsEventDto> dtos = new ArrayList<>();
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,8,0))
-                .endTime(LocalDateTime.of(2024,8,2,0,0))
+                .startTime(LocalDateTime.of(2024,8,1,8,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,0,0).atZone(ZoneOffset.UTC).toInstant())
                 .build() // 끝 시간 겹침
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,0,0))
-                .endTime(LocalDateTime.of(2024,8,1,4,0))
+                .startTime(LocalDateTime.of(2024,8,1,0,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
                 .build() // 시작 시간 겹침
         );
         dtos.add(FcfsEventDto.builder()
-                .startTime(LocalDateTime.of(2024,8,1,4,0))
-                .endTime(LocalDateTime.of(2024,8,1,8,0))
+                .startTime(LocalDateTime.of(2024,8,1,4,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,8,0).atZone(ZoneOffset.UTC).toInstant())
                 .build() // 시간끼리 겹침
         );
         // 점에서 겹치는 것은 겹친다고 취급 안한다.

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchEventsTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,48 +40,48 @@ class EventServiceSearchEventsTest extends IntegrationDataJpaTest {
         EventMetadata em1 = EventMetadata.builder()
                 .eventId("HD240805_001")
                 .name("hyundai car event")
-                .startTime(LocalDateTime.of(2024,8,1,15,0))
-                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .startTime(LocalDateTime.of(2024,8,1,15,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,15,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 
         EventMetadata em2 = EventMetadata.builder()
                 .eventId("HD240805_002")
                 .name("hello bye")
-                .startTime(LocalDateTime.of(2024,8,1,15,0))
-                .endTime(LocalDateTime.of(2024,8,2,17,0))
+                .startTime(LocalDateTime.of(2024,8,1,15,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,17,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 
         EventMetadata em3 = EventMetadata.builder()
                 .eventId("HD240805_003")
                 .name("hyundai car event")
-                .startTime(LocalDateTime.of(2024,8,1,18,0))
-                .endTime(LocalDateTime.of(2024,8,1,20,0))
+                .startTime(LocalDateTime.of(2024,8,1,18,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,20,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 
         EventMetadata em4 = EventMetadata.builder()
                 .eventId("HD240805_004")
                 .name("25 always opened")
-                .startTime(LocalDateTime.of(2024,8,1,19,0))
-                .endTime(LocalDateTime.of(2024,8,1,20,0))
+                .startTime(LocalDateTime.of(2024,8,1,19,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,20,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 
         EventMetadata em5 = EventMetadata.builder()
                 .eventId("HD240805_005")
                 .name("zebra car event")
-                .startTime(LocalDateTime.of(2024,8,1,21,0))
-                .endTime(LocalDateTime.of(2024,8,1,22,0))
+                .startTime(LocalDateTime.of(2024,8,1,21,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,22,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 
         EventMetadata em6 = EventMetadata.builder()
                 .eventId("HD240805_006")
                 .name("25 always opened")
-                .startTime(LocalDateTime.of(2024,8,1,22,0))
-                .endTime(LocalDateTime.of(2024,8,1,23,0))
+                .startTime(LocalDateTime.of(2024,8,1,22,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,1,23,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .build();
 

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceSearchHintsTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,8 +43,8 @@ class EventServiceSearchHintsTest extends IntegrationDataJpaTest {
         EventMetadata em1 = EventMetadata.builder()
                 .eventId("HD240805_001")
                 .name("hyundai car event")
-                .startTime(LocalDateTime.of(2024,8,1,15,0))
-                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .startTime(LocalDateTime.of(2024,8,1,15,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,15,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .eventType(EventType.draw)
                 .build();
@@ -51,8 +52,8 @@ class EventServiceSearchHintsTest extends IntegrationDataJpaTest {
         EventMetadata em2 = EventMetadata.builder()
                 .eventId("HD240905_002")
                 .name("hyundai car event")
-                .startTime(LocalDateTime.of(2024,8,1,15,0))
-                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .startTime(LocalDateTime.of(2024,8,1,15,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,15,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .eventType(EventType.draw)
                 .build();
@@ -60,8 +61,8 @@ class EventServiceSearchHintsTest extends IntegrationDataJpaTest {
         EventMetadata em3 = EventMetadata.builder()
                 .eventId("HD240805_003")
                 .name("hyundai car event")
-                .startTime(LocalDateTime.of(2024,8,1,15,0))
-                .endTime(LocalDateTime.of(2024,8,2,15,0))
+                .startTime(LocalDateTime.of(2024,8,1,15,0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024,8,2,15,0).atZone(ZoneOffset.UTC).toInstant())
                 .eventFrame(ef)
                 .eventType(EventType.fcfs)
                 .build();

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/EventParticipationServiceTest.java
@@ -15,7 +15,9 @@ import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -80,8 +82,8 @@ class EventParticipationServiceTest {
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(eventMetadata));
         var mockDto1 = mock(EventParticipationDateDto.class);
         var mockDto2 = mock(EventParticipationDateDto.class);
-        when(mockDto1.getDate()).thenReturn(LocalDateTime.now());
-        when(mockDto2.getDate()).thenReturn(LocalDateTime.now());
+        when(mockDto1.getDate()).thenReturn(Instant.now());
+        when(mockDto2.getDate()).thenReturn(Instant.now());
 
         when(epiRepository.findByEventUserId(any(), any())).thenReturn(List.of(mockDto1, mockDto2));
 
@@ -157,8 +159,8 @@ class EventParticipationServiceTest {
     @Test
     void participateAtDate_throwIfNotEventTime() {
         var eventMetadata = EventMetadata.builder()
-                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
-                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0))
+                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
                 .eventType(EventType.draw)
                 .eventFrameId(frameId)
                 .build();
@@ -166,7 +168,7 @@ class EventParticipationServiceTest {
 
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(eventMetadata));
 
-        LocalDateTime now = LocalDateTime.of(2024, 9, 1, 0, 0, 0);
+        Instant now = LocalDateTime.of(2024, 9, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant();
 
         // 유저 있음
         EventUser user = mock(EventUser.class);
@@ -185,8 +187,8 @@ class EventParticipationServiceTest {
     @Test
     void participateAtDate_throwIfAlreadyParticipated() {
         var eventMetadata = EventMetadata.builder()
-                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
-                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0))
+                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
                 .eventType(EventType.draw)
                 .eventFrameId(frameId)
                 .build();
@@ -194,7 +196,7 @@ class EventParticipationServiceTest {
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(eventMetadata));
 
         // 이벤트 기간 내
-        LocalDateTime now = LocalDateTime.of(2024, 8, 3, 0, 0, 0);
+        Instant now = LocalDateTime.of(2024, 8, 3, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant();
         // 오늘 참여함
         when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any())).thenReturn(true);
 
@@ -215,8 +217,8 @@ class EventParticipationServiceTest {
     @Test
     void participateAtDate_participateSuccessfully() {
         var eventMetadata = EventMetadata.builder()
-                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0))
-                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0))
+                .startTime(LocalDateTime.of(2024, 8, 1, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
+                .endTime(LocalDateTime.of(2024, 8, 10, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant())
                 .eventType(EventType.draw)
                 .eventFrameId(frameId)
                 .build();
@@ -224,7 +226,7 @@ class EventParticipationServiceTest {
         when(emRepository.findFirstByEventId(anyString())).thenReturn(Optional.of(eventMetadata));
 
         // 이벤트 기간 내
-        LocalDateTime now = LocalDateTime.of(2024, 8, 3, 0, 0, 0);
+        Instant now = LocalDateTime.of(2024, 8, 3, 0, 0, 0).atZone(ZoneOffset.UTC).toInstant();
         // 오늘 참여안함
         when(epiRepository.existsByEventUserAndDrawEventAndDateBetween(any(), any(), any(), any())).thenReturn(false);
 

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsControllerTest.java
@@ -26,6 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.*;
@@ -146,7 +147,7 @@ class FcfsControllerTest {
     @Test
     void getFcfsInfoTest() throws Exception {
         // given
-        ResponseFcfsInfoDto responseFcfsInfoDto = new ResponseFcfsInfoDto(LocalDateTime.now(), "waiting");
+        ResponseFcfsInfoDto responseFcfsInfoDto = new ResponseFcfsInfoDto(Instant.now(), "waiting");
         when(fcfsManageService.getFcfsInfo(eventId)).thenReturn(responseFcfsInfoDto);
         String responseBody = mapper.writeValueAsString(responseFcfsInfoDto);
 

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
@@ -24,7 +24,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.core.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -66,7 +68,7 @@ class FcfsManageServiceTest {
     EventFrame eventFrame = EventFrame.of("the-new-ioniq5","FcfsManageServiceTest");
     EventUser eventUser = EventUser.of("test", "0101234567", eventFrame, "uuid");
     FcfsEvent fcfsEvent = FcfsEvent.builder()
-            .startTime(LocalDateTime.now().plusSeconds(10))
+            .startTime(Instant.now().plus(10, ChronoUnit.SECONDS))
             .participantCount(100L)
             .build();
 
@@ -81,7 +83,7 @@ class FcfsManageServiceTest {
     @Test
     void registerFcfsEventsTest() {
         // given
-        given(fcfsEventRepository.findByStartTimeBetween(LocalDateTime.now(), LocalDateTime.now().plusDays(1)))
+        given(fcfsEventRepository.findByStartTimeBetween(Instant.now(), Instant.now().plus(1, ChronoUnit.DAYS)))
                 .willReturn(new ArrayList<>(List.of(fcfsEvent)));
 
         // when
@@ -122,7 +124,7 @@ class FcfsManageServiceTest {
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(eventId)).willReturn(fcfsEventId.toString());
         given(valueOperations.get(FcfsUtil.startTimeFormatting(fcfsEventId.toString())))
-                .willReturn(LocalDateTime.now().minusMinutes(minute).toString());
+                .willReturn(Instant.now().minus(minute, ChronoUnit.MINUTES).toString());
 
         // when
         ResponseFcfsInfoDto fcfsInfo = fcfsManageService.getFcfsInfo(eventId);
@@ -138,7 +140,7 @@ class FcfsManageServiceTest {
         // given
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(FcfsUtil.startTimeFormatting(fcfsEventId.toString())))
-                .willReturn(LocalDateTime.now().plusMinutes(minute).toString());
+                .willReturn(Instant.now().plus(minute, ChronoUnit.MINUTES).toString());
 
         // when
         ResponseFcfsInfoDto fcfsInfo = fcfsManageService.getFcfsInfo(eventId);
@@ -154,7 +156,7 @@ class FcfsManageServiceTest {
         // given
         given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(FcfsUtil.startTimeFormatting(fcfsEventId.toString())))
-                .willReturn(LocalDateTime.now().minusMinutes(minute).toString());
+                .willReturn(Instant.now().plus(minute, ChronoUnit.MINUTES).toString());
 
         // when
         ResponseFcfsInfoDto fcfsInfo = fcfsManageService.getFcfsInfo(eventId);
@@ -207,7 +209,7 @@ class FcfsManageServiceTest {
     @Test
     void getFcfsWinnersInfoTest() {
         // given
-        LocalDateTime now = LocalDateTime.now();
+        Instant now = Instant.now();
         given(fcfsEventWinningInfoRepository.findByFcfsEventId(fcfsEventId))
                 .willReturn(List.of(FcfsEventWinningInfo.of(fcfsEvent, eventUser, now)));
 

--- a/src/test/java/hyundai/softeer/orange/load/DbFcfsServiceLoadTest.java
+++ b/src/test/java/hyundai/softeer/orange/load/DbFcfsServiceLoadTest.java
@@ -19,7 +19,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.TestPropertySource;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -71,7 +72,7 @@ class DbFcfsServiceLoadTest {
                 .eventId(eventId)
                 .build();
         eventMetadataRepository.save(eventMetadata);
-        FcfsEvent fcfsEvent = FcfsEvent.of(LocalDateTime.now(), LocalDateTime.now().plusDays(1), numberOfWinners, "prizeInfo", eventMetadata);
+        FcfsEvent fcfsEvent = FcfsEvent.of(Instant.now(), Instant.now().plus(24, ChronoUnit.HOURS), numberOfWinners, "prizeInfo", eventMetadata);
         fcfsEventRepository.save(fcfsEvent);
         stringRedisTemplate.opsForValue().set(eventId, fcfsEvent.getId().toString());
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #115

## 📝 작업 내용
LocalDateTime 기반으로 작성되었던 코드를 UTC+0 기준으로 동작하는 Instant로 전환했습니다.

현재 프로젝트는 ISO8601 표준 UTC 시간 표기 방식 ( YYYY-MM-DDThh:mm:ssZ 형식 ) 을 기준으로 날짜 정보를 프론트엔드 - 백엔드 간 통신하고 있습니다. 이때, 백엔드 내부적으로 이용하고 있는 시간 표현은 LocalDateTime으로, 타임존 정보가 존재하지 않는다는 특징이 있습니다.

문제는 서버측에서 다루는 시간에 타임존이 없어 DB에서 가져온 UTC 시간을 왜곡하는 부분에서 발생했습니다. 프론트엔드 측은 UTC 타임존 정보를 포함하여 데이터를 전달하지만, 해당 값을 LocalDatetime으로 변환하는 과정에서 UTC가 아닌 KST(한국 시간 = UTC+9)로 인식됩니다. 마찬가지로 DB에는 UTC 시간을 기준으로 datetime(6) 데이터를 저장하지만, 이를 Spring으로 가져와 다룰 때는 KST로 인식되어 의도와는 달리 9시간의 시간 오차가 지속적으로 발생하고 있었습니다.

현재 "서버의 현지 시간"이 중요한 상황은 거의 존재하지 않습니다. 대부분의 경우 DB에 저장된 UTC 시간을 기준으로 값을 비교하더라도 문제가 없으며, 일부 당일 액션 체크가 필요한 경우에는 LocalDateTime을 UTC 시간 기준으로 변경해서 처리할 수 있습니다.

확장성 측면에서도 DB에 한국의 로컬 시간 대신 UTC 시간을 저장하는 경우, 다른 서비스에서 DB를 접근할 때 타임존을 신경쓰지 않고 통일된 시간대로 문제를 처리할 수 있다는 점이 장점이라고 생각했습니다. 장기적으로 볼 때 현재 어드민 시스템은 국내 뿐만 아니라 다양한 국외 환경에 대응해야 할지 모릅니다. 이 상황을 가정하면 타임존을 배제, UTC 기준으로 DB와 로직을 구현하는 것이 하나의 빌드로 여러 국가에 대응하는데 큰 도움이 될 수 있습니다.

위와 같은 이유로 LocalDateTime을 걷어내고 UTC 기준으로 동작하는 시간 API인 Instant로 전환했습니다. 장기적으로 현재 시스템을 확장해나갈 예정이라면 이벤트에 타임존 필드를 추가, 해당 타임존을 기반으로 하루를 계산할 수 있도록 구성하면 더 확장적인 서비스가 될 수 있을 것이라 생각합니다.

## 고려한 점
1. LocalDatetime 대신 Instant를 사용하도록 변경: 동일 서버를 어떤 국가에 배포하더라도 DB 상의 데이터를 동일한 UTC 시간으로 인식하고 처리할 수 있도록 구성.
2. 이벤트 키 수명 48시간으로 지정: 현재 가장 시간이 빠른 나라와 가장 느린 나라는 UTC-12, UTC+12의 시간대를 가질 수 있으며, 시차는 24시간에 해당한다. 하루에 해당하는 24시간 + 시차 24시간을 더해 키 수명을 48시간으로 지정하여 어떤 나라에서도 이벤트 키를 충돌 없이 생성할 수 있도록 구성 ( 각 지역이 동일한 db를 사용할 수 있다고 가정 )
3. 서머 타임에 의한 시간 변동을 반영하는 ZoneId 대신 엄밀한 시간 차이를 반영하는 ZoneOffset을 이용