### PR TITLE
[fix] 이벤트 수정 시 fcfs / draw에서 2개 이상의 객체 추가 시 예외 발생하는 현상 수정(#124) 

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/component/eventFieldMapper/mapper/DrawEventFieldMapper.java
@@ -107,11 +107,13 @@ public class DrawEventFieldMapper implements EventFieldMapper {
     private void editDrawEventMetadata(DrawEvent drawEvent, DrawEventDto drawEventDto) {
         List<DrawEventMetadata> deMetadata = drawEvent.getMetadataList();
 
-        Map<Boolean, Map<Long, DrawEventMetadataDto>> deMetadataDtos = drawEventDto.getMetadata().stream()
-                .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(DrawEventMetadataDto::getId, it-> it)));
-        // true이면 created / false이면 updated
-        Map<Long, DrawEventMetadataDto> createdDtos = deMetadataDtos.get(true);
-        Map<Long, DrawEventMetadataDto> updatedDtos = deMetadataDtos.get(false);
+        List<DrawEventMetadataDto> createdDtos = new ArrayList<>();
+        Map<Long, DrawEventMetadataDto> updatedDtos = new HashMap<>();
+
+        drawEventDto.getMetadata().forEach(it -> {
+            if(it.getId() == null) createdDtos.add(it);
+            else updatedDtos.put(it.getId(), it);
+        });
 
         Set<Long> updated = new HashSet<>(updatedDtos.keySet());
         Set<Long> deleted = deMetadata.stream().map(DrawEventMetadata::getId).collect(Collectors.toSet());
@@ -135,7 +137,7 @@ public class DrawEventFieldMapper implements EventFieldMapper {
         deMetadata.removeIf(it -> deleted.contains(it.getId()));
 
         // 객체 생성 처리
-        for(DrawEventMetadataDto createdDto : createdDtos.values()) {
+        for(DrawEventMetadataDto createdDto : createdDtos) {
             DrawEventMetadata drawEventMetadata = DrawEventMetadata.of(
                     createdDto.getGrade(),
                     createdDto.getCount(),
@@ -149,11 +151,13 @@ public class DrawEventFieldMapper implements EventFieldMapper {
     private void editDrawEventScorePolicy(DrawEvent drawEvent, DrawEventDto drawEventDto) {
         List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();
 
-        Map<Boolean, Map<Long, DrawEventScorePolicyDto>> deMetadataDtos = drawEventDto.getPolicies().stream()
-                .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(DrawEventScorePolicyDto::getId, it-> it)));
-        // true이면 created / false이면 updated
-        Map<Long, DrawEventScorePolicyDto> createdDtos = deMetadataDtos.get(true);
-        Map<Long, DrawEventScorePolicyDto> updatedDtos = deMetadataDtos.get(false);
+        List<DrawEventScorePolicyDto> createdDtos = new ArrayList<>();
+        Map<Long, DrawEventScorePolicyDto> updatedDtos = new HashMap<>();
+
+        drawEventDto.getPolicies().forEach(it -> {
+            if(it.getId() == null) createdDtos.add(it);
+            else updatedDtos.put(it.getId(), it);
+        });
 
         Set<Long> updated = new HashSet<>(updatedDtos.keySet());
         Set<Long> deleted = policies.stream().map(DrawEventScorePolicy::getId).collect(Collectors.toSet());
@@ -176,7 +180,7 @@ public class DrawEventFieldMapper implements EventFieldMapper {
         policies.removeIf(it -> deleted.contains(it.getId()));
 
         // 객체 생성 처리
-        for(DrawEventScorePolicyDto createdDto : createdDtos.values()) {
+        for(DrawEventScorePolicyDto createdDto : createdDtos) {
             DrawEventScorePolicy policy = DrawEventScorePolicy.of(
                     createdDto.getAction(),
                     createdDto.getScore(),

--- a/src/main/java/hyundai/softeer/orange/event/dto/group/EventEditGroup.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/group/EventEditGroup.java
@@ -1,4 +1,7 @@
 package hyundai.softeer.orange.event.dto.group;
 
-public interface EventEditGroup {
+import jakarta.validation.groups.Default;
+
+// default 그룹 = 비어있을 때 모두 포함을 함께 적용할 수 있음.
+public interface EventEditGroup extends Default {
 }

--- a/src/test/resources/sql/RefreshTable.sql
+++ b/src/test/resources/sql/RefreshTable.sql
@@ -1,6 +1,6 @@
+SET FOREIGN_KEY_CHECKS = 0;
 TRUNCATE TABLE url;
 TRUNCATE TABLE admin_user;
-
 TRUNCATE TABLE draw_event_score_policy;
 TRUNCATE TABLE draw_event_metadata;
 TRUNCATE TABLE draw_event_winning_info;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #124

# 📝 작업 내용

1. 이벤트 수정 시 이벤트 세부 타입의 특정 필드( fcfs / draw - metadata / policy )를 2개 이상 추가하려고 할 때 예외가 발생하는 문제 수정 
2. 이벤트를 수정할 때는 이벤트의 대부분의 필드를 검증하지 않는 문제 수정 

## 1번 문제 원인 & 해결 방법

현재 서버는 이벤트를 수정할 때 다음과 같은 로직을 적용합니다.

1. 클라이언트 측 데이터에서 id 값이 없는 경우 => 생성
2. 클라이언트 측 데이터 + db에 있고 id 값이 있는 경우 => 갱신
3. db에만 있는 경우 => 삭제

```java
Map<Boolean, Map<Long, DrawEventScorePolicyDto>> deMetadataDtos = drawEventDto.getPolicies().stream()
        .collect(Collectors.partitioningBy(it -> it.getId() == null, Collectors.toMap(DrawEventScorePolicyDto::getId, it-> it)));
```
기존에는 생성 / 갱신 대상을 판정하는 과정에서 key == null을 기준으로 2개의 map을 만들어 처리했습니다. 이때 생성하는 데이터가 여러개인 경우 key == null인 데이터가 여러개가 되므로 키 충돌 문제가 발생했습니다. 따라서 for문을 순회하며 key == null인 경우 리스트에, null이 아닌 경우에는 map에 삽입하여 처리하는 방식으로 코드를 수정했습니다.

```java
 List<DrawEventScorePolicyDto> createdDtos = new ArrayList<>();
 Map<Long, DrawEventScorePolicyDto> updatedDtos = new HashMap<>();

  drawEventDto.getPolicies().forEach(it -> {
      if(it.getId() == null) createdDtos.add(it);
      else updatedDtos.put(it.getId(), it);
  });
```

## 2번 문제 원인 & 해결 방법

Bean Validation은 group을 지정하지 않으면 Default 그룹을 지정합니다. 이때 명시적으로 그룹을 지정해주면 Default 그룹이 무시되어 평가되지 않습니다. 특정 그룹이 다른 그룹을 상속하면 두 그룹을 모두 포함하는 특성이 있으므로, EditGroup이 Default 그룹을 상속하게 만들어 문제를 해결했습니다.

```java
public interface EventEditGroup extends Default {
}

```