### PR TITLE
[chore] Redis Key Name 난잡한 상황 개선 (#129)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -49,13 +49,13 @@ public class FcfsManageService {
     // redis에 저장된 모든 선착순 이벤트의 당첨자 정보를 DB로 이관
     @Transactional
     public void registerWinners() {
-        Set<String> fcfsIds = stringRedisTemplate.keys("*:fcfs");
+        Set<String> fcfsIds = stringRedisTemplate.keys("*:count");
         if (fcfsIds == null || fcfsIds.isEmpty()) {
             return;
         }
 
         for(String fcfsId : fcfsIds) {
-            String eventId = fcfsId.replace(":fcfs", "");
+            String eventId = fcfsId.replace(":count", "").replace("fcfs:", "");
             Set<String> userIds = stringRedisTemplate.opsForZSet().range(FcfsUtil.winnerFormatting(eventId), 0, -1);
             if(userIds == null || userIds.isEmpty()) {
                 return;

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -8,38 +8,36 @@ public class FcfsUtil {
 
     private static final String FCFS_PREFIX = "fcfs:";
 
-    // 참여할 선착순 이벤트의 식별자를 간접적으로 보관하는 tag, key는 선착순 이벤트와 연결된 eventMetadata의 eventId이다.
     public static String eventIdFormatting(String key) {
-        return FCFS_PREFIX + key + ":eventId";
+        return formatKey(key, "eventId");
     }
 
-    // 선착순 이벤트 tag
     public static String keyFormatting(String key) {
-        return FCFS_PREFIX + key + ":count";
+        return formatKey(key, "count");
     }
 
-    // 선착순 이벤트 시작 시각 tag
     public static String startTimeFormatting(String key) {
-        return FCFS_PREFIX + key + ":start";
+        return formatKey(key, "start");
     }
 
-    // 선착순 이벤트 마감 여부 tag
     public static String endFlagFormatting(String key) {
-        return FCFS_PREFIX + key + ":end";
+        return formatKey(key, "end");
     }
 
-    // 선착순 이벤트 당첨자 tag
     public static String winnerFormatting(String key) {
-        return FCFS_PREFIX + key + ":winner";
+        return formatKey(key, "winner");
     }
 
-    // 선착순 이벤트 참여자 tag
     public static String participantFormatting(String key) {
-        return FCFS_PREFIX + key + ":participant";
+        return formatKey(key, "participant");
     }
 
-    // 선착순 이벤트 정답 tag
     public static String answerFormatting(String key) {
-        return FCFS_PREFIX + key + ":answer";
+        return formatKey(key, "answer");
+    }
+
+    // 공통 로직을 처리하는 메서드
+    private static String formatKey(String key, String suffix) {
+        return FCFS_PREFIX + key + ":" + suffix;
     }
 }

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/util/FcfsUtil.java
@@ -6,38 +6,40 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FcfsUtil {
 
-    // 선착순 이벤트의 PK를 간접적으로 보관하는 eventId tag
+    private static final String FCFS_PREFIX = "fcfs:";
+
+    // 참여할 선착순 이벤트의 식별자를 간접적으로 보관하는 tag, key는 선착순 이벤트와 연결된 eventMetadata의 eventId이다.
     public static String eventIdFormatting(String key) {
-        return key + ":eventId";
+        return FCFS_PREFIX + key + ":eventId";
     }
 
     // 선착순 이벤트 tag
     public static String keyFormatting(String key) {
-        return key + ":fcfs";
+        return FCFS_PREFIX + key + ":count";
     }
 
     // 선착순 이벤트 시작 시각 tag
     public static String startTimeFormatting(String key) {
-        return key + ":start";
+        return FCFS_PREFIX + key + ":start";
     }
 
     // 선착순 이벤트 마감 여부 tag
     public static String endFlagFormatting(String key) {
-        return key + ":end";
+        return FCFS_PREFIX + key + ":end";
     }
 
     // 선착순 이벤트 당첨자 tag
     public static String winnerFormatting(String key) {
-        return key + ":winner";
+        return FCFS_PREFIX + key + ":winner";
     }
 
     // 선착순 이벤트 참여자 tag
     public static String participantFormatting(String key) {
-        return key + ":participant";
+        return FCFS_PREFIX + key + ":participant";
     }
 
     // 선착순 이벤트 정답 tag
     public static String answerFormatting(String key) {
-        return key + ":answer";
+        return FCFS_PREFIX + key + ":answer";
     }
 }

--- a/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/fcfs/FcfsManageServiceTest.java
@@ -25,7 +25,6 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.core.*;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +97,7 @@ class FcfsManageServiceTest {
     @Test
     void registerWinnersTest() {
         // given
-        given(stringRedisTemplate.keys("*:fcfs")).willReturn(Set.of("1:fcfs"));
+        given(stringRedisTemplate.keys("*:count")).willReturn(Set.of("1:count"));
         given(stringRedisTemplate.opsForZSet()).willReturn(zSetOperations);
         given(zSetOperations.range(FcfsUtil.winnerFormatting(fcfsEventId.toString()), 0, -1))
                 .willReturn(Set.of(eventUser.getUserId()));
@@ -109,7 +108,7 @@ class FcfsManageServiceTest {
         fcfsManageService.registerWinners();
 
         // then
-        verify(stringRedisTemplate).keys("*:fcfs");
+        verify(stringRedisTemplate).keys("*:count");
         verify(zSetOperations).range(FcfsUtil.winnerFormatting(fcfsEventId.toString()), 0, -1);
         verify(fcfsEventRepository).findById(fcfsEventId);
         verify(eventUserRepository).findAllByUserId(List.of(eventUser.getUserId()));


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #129

# 📝 작업 내용

> 이제 선착순 이벤트와 관련된 Redis의 key의 의미를 명확하게 표현하도록 수정했습니다.
>
> 기존에는 단순 숫자와 suffix만으로 key를 만들었기 때문에 만약 다른 기능에서 유사한 구조의 key가 도입될 경우 난잡해질 수 있다는 단점이 있었습니다.

## 참고 이미지 및 자료
<img width="165" alt="image" src="https://github.com/user-attachments/assets/61770b6b-3d72-49fe-8061-9de7fba2d871">

<img width="128" alt="image" src="https://github.com/user-attachments/assets/55e816b8-dba0-4791-a3a4-fac0cf3a120f">

# 💬 리뷰 요구사항
