### PR TITLE
[feat] 이벤트 삭제 기능 구현(#131)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -63,7 +63,7 @@ public class AdminEventController {
     @PostMapping
     @Operation(summary = "이벤트 생성", description = "관리자가 이벤트를 새롭게 등록한다", responses = {
             @ApiResponse(responseCode = "201", description = "이벤트 생성 성공"),
-            @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패")
+            @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> createEvent(@Validated @RequestBody EventDto eventDto,
                                             @Parameter(hidden = true) @AdminAnnotation AdminDto admin
@@ -80,15 +80,33 @@ public class AdminEventController {
      * @return 해당 이벤트에 대한 정보
      */
     @GetMapping("{eventId}")
-    @Operation(summary = "이벤트 데이터 획득", description = "이벤트 초기 정보를 받는다. 상세 정보, 이벤트 수정 모두에서 사용 가능", responses = {
+    @Operation(summary = "이벤트 획득", description = "이벤트 상세 정보를 받는다. 상세 정보, 이벤트 수정 모두에서 사용 가능", responses = {
             @ApiResponse(responseCode = "200", description = "이벤트 정보를 정상적으로 받음"),
-            @ApiResponse(responseCode = "404", description = "대응되는 이벤트가 존재하지 않음")
+            @ApiResponse(responseCode = "404", description = "대응되는 이벤트가 존재하지 않음",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<EventDto> getEventData(
+    public ResponseEntity<EventDto> getEvent(
             @PathVariable("eventId") String eventId
     ) {
         EventDto eventInfo = eventService.getEventInfo(eventId);
         return ResponseEntity.ok(eventInfo);
+    }
+
+    /**
+     *
+     * @param eventId 이벤트 ID. HD000000~로 시작하는 그것
+     * @return 해당 이벤트에 대한 정보
+     */
+    @DeleteMapping("{eventId}")
+    @Operation(summary = "이벤트 제거", description = "이벤트를 제거한다. 시작 전의 이벤트만 삭제할 수 있다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트를 정상적으로 삭제"),
+            @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음",content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이벤트가 진행 중이거나 종료되어 삭제할 수 없음",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<Void> deleteEvent(
+            @PathVariable("eventId") String eventId
+    ) {
+        eventService.deleteEvent(eventId);
+        return ResponseEntity.ok().build();
     }
 
     /**
@@ -97,7 +115,7 @@ public class AdminEventController {
     @PostMapping("/edit")
     @Operation(summary = "이벤트 수정", description = "관리자가 이벤트를 수정한다", responses = {
             @ApiResponse(responseCode = "200", description = "이벤트 생성 성공"),
-            @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패")
+            @ApiResponse(responseCode = "4xx", description = "유저 측 실수로 이벤트 생성 실패",content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> editEvent(
             @Validated({EventEditGroup.class}) @RequestBody EventDto eventDto) {
@@ -111,7 +129,7 @@ public class AdminEventController {
     @PostMapping("/frame")
     @Operation(summary = "이벤트 프레임 생성", description = "관리자가 이벤트 프레임을 새롭게 등록한다", responses = {
             @ApiResponse(responseCode = "201", description = "이벤트 프레임 생성 성공"),
-            @ApiResponse(responseCode = "4xx", description = "이벤트 프레임 생성 실패")
+            @ApiResponse(responseCode = "4xx", description = "이벤트 프레임 생성 실패" ,content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<Void> createEventFrame(@Valid @RequestBody EventFrameCreateRequest req) {
         eventService.createEventFrame(req.getFrameId(), req.getName());

--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -9,58 +9,60 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     // 400 Bad Request
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, false, "잘못된 요청입니다."),
-    INVALID_COMMENT(HttpStatus.BAD_REQUEST, false, "부정적인 표현을 사용하였습니다."),
-    INVALID_JSON(HttpStatus.BAD_REQUEST, false, "잘못된 JSON 형식입니다."),
-    INVALID_URL(HttpStatus.BAD_REQUEST, false, "유효하지 않은 URL입니다."),
-    INVALID_INPUT_EVENT_TIME(HttpStatus.BAD_REQUEST, false, "입력된 시간 중 일부가 조건에 맞지 않습니다."),
-    INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, false, "이벤트 시간이 아닙니다."),
-    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, false, "이벤트 타입이 지원되지 않습니다."),
-    EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, false, "이벤트가 아직 종료되지 않았습니다."),
-    EVENT_IS_DRAWING(HttpStatus.BAD_REQUEST, false, "현재 추첨이 진행되고 있는 이벤트입니다."),
-    DUPLICATED_POLICIES(HttpStatus.BAD_REQUEST,false,"정책에서 중복된 액션이 존재합니다."),
-    DUPLICATED_GRADES(HttpStatus.BAD_REQUEST,false,"추첨 이벤트 정보에 중복된 등수가 존재합니다."),
-    CANNOT_PARTICIPATE(HttpStatus.BAD_REQUEST,false,"현재 유저가 참여할 수 없는 이벤트입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "부정적인 표현을 사용하였습니다."),
+    INVALID_JSON(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
+    INVALID_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 URL입니다."),
+    INVALID_INPUT_EVENT_TIME(HttpStatus.BAD_REQUEST, "입력된 시간 중 일부가 조건에 맞지 않습니다."),
+    INVALID_EVENT_TIME(HttpStatus.BAD_REQUEST, "이벤트 시간이 아닙니다."),
+    INVALID_EVENT_TYPE(HttpStatus.BAD_REQUEST, "이벤트 타입이 지원되지 않습니다."),
+    EVENT_NOT_ENDED(HttpStatus.BAD_REQUEST, "이벤트가 아직 종료되지 않았습니다."),
+    EVENT_IS_DRAWING(HttpStatus.BAD_REQUEST, "현재 추첨이 진행되고 있는 이벤트입니다."),
+    DUPLICATED_POLICIES(HttpStatus.BAD_REQUEST,"정책에서 중복된 액션이 존재합니다."),
+    DUPLICATED_GRADES(HttpStatus.BAD_REQUEST,"추첨 이벤트 정보에 중복된 등수가 존재합니다."),
+    CANNOT_PARTICIPATE(HttpStatus.BAD_REQUEST,"현재 유저가 참여할 수 없는 이벤트입니다."),
+    CANNOT_DELETE_EVENT_RUNNING(HttpStatus.BAD_REQUEST,"이벤트가 진행 중이므로 삭제할 수 없습니다"),
+    CANNOT_DELETE_EVENT_ENDED(HttpStatus.BAD_REQUEST,"이벤트가 종료되어 삭제할 수 없습니다"),
+
 
     // 401 Unauthorized
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, false, "인증되지 않은 사용자입니다."),
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, false, "아이디 또는 비밀번호가 일치하지 않습니다"),
-    INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, false, "인증번호가 일치하지 않습니다."),
-    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, false, "세션이 만료되었습니다."),
-    AUTH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, false, "인증번호가 만료되었거나 존재하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다"),
+    INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."),
+    SESSION_EXPIRED(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다."),
+    AUTH_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "인증번호가 만료되었거나 존재하지 않습니다."),
 
     // 403 Forbidden
-    FORBIDDEN(HttpStatus.FORBIDDEN, false, "권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
 
     // 404 Not Found
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
-    SHORT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, false, "단축 URL을 찾을 수 없습니다."),
-    FCFS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "선착순 이벤트를 찾을 수 없습니다."),
-    DRAW_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "추첨 이벤트를 찾을 수 없습니다."),
-    EVENT_FRAME_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 프레임을 찾을 수 없습니다."),
-    EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트 사용자를 찾을 수 없습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "기대평을 찾을 수 없습니다."),
-    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이벤트를 찾을 수 없습니다."),
-    EVENT_NOT_PARTICIPATED(HttpStatus.NOT_FOUND, false, "이벤트에 참여하지 않았습니다."),
-    TEMP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "임시 저장 된 이벤트가 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    SHORT_URL_NOT_FOUND(HttpStatus.NOT_FOUND, "단축 URL을 찾을 수 없습니다."),
+    FCFS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "선착순 이벤트를 찾을 수 없습니다."),
+    DRAW_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "추첨 이벤트를 찾을 수 없습니다."),
+    EVENT_FRAME_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트 프레임을 찾을 수 없습니다."),
+    EVENT_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트 사용자를 찾을 수 없습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "기대평을 찾을 수 없습니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "이벤트를 찾을 수 없습니다."),
+    EVENT_NOT_PARTICIPATED(HttpStatus.NOT_FOUND, "이벤트에 참여하지 않았습니다."),
+    TEMP_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "임시 저장 된 이벤트가 없습니다."),
 
     // 405 Method Not Allowed
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, false, "허용되지 않은 메서드입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
 
     // 409 Conflict
-    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
-    SHORT_URL_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 URL입니다."),
-    COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 등록된 기대평입니다."),
-    ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 관리자입니다."),
-    ALREADY_WINNER(HttpStatus.CONFLICT, false, "이미 당첨된 사용자입니다."),
-    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, false, "이미 참여한 사용자입니다."),
-    PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 전화번호입니다."),
-    ALREADY_DRAWN(HttpStatus.CONFLICT, false, "이미 추첨된 이벤트입니다."),
+    USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 사용자입니다."),
+    SHORT_URL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 URL입니다."),
+    COMMENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 기대평입니다."),
+    ADMIN_USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 관리자입니다."),
+    ALREADY_WINNER(HttpStatus.CONFLICT, "이미 당첨된 사용자입니다."),
+    ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "이미 참여한 사용자입니다."),
+    PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 전화번호입니다."),
+    ALREADY_DRAWN(HttpStatus.CONFLICT, "이미 추첨된 이벤트입니다."),
 
     // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생하였습니다.");
 
     private final HttpStatus httpStatus;
-    private final Boolean success;
     private final String message;
 }

--- a/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/entity/EventMetadata.java
@@ -82,7 +82,7 @@ public class EventMetadata {
     private Long eventFrameId;
 
     // 원래는 one-to-one 관계이지만, JPA 동작에 의해 강제로 EAGER FETCH로 처리돰 -> one-to-many 로 관리
-    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "eventMetadata", cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
     private final List<DrawEvent> drawEventList = new ArrayList<>();
 
     public void updateDrawEvent(DrawEvent drawEvent) {
@@ -94,7 +94,7 @@ public class EventMetadata {
         return drawEventList.get(0);
     }
 
-    @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @OneToMany(mappedBy = "eventMetaData", cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE}, fetch = FetchType.LAZY)
     private final List<FcfsEvent> fcfsEventList = new ArrayList<>();
 
     public void addFcfsEvents(List<FcfsEvent> fcfsEventList) {

--- a/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/entity/DrawEvent.java
@@ -29,12 +29,12 @@ public class DrawEvent {
     private EventMetadata eventMetadata;
 
     @OneToMany(mappedBy ="drawEvent",
-            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
             fetch = FetchType.EAGER) // 추첨 이벤트는 항상 policy와 함께 사용되므로 EAGER로 설정
     private List<DrawEventScorePolicy> policyList = new ArrayList<>();
 
     @OneToMany(mappedBy ="drawEvent",
-            cascade = {CascadeType.PERSIST, CascadeType.MERGE},
+            cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REMOVE},
             fetch = FetchType.EAGER) // 추첨 이벤트는 항상 metadata와 함께 사용되므로 EAGER로 설정
     private List<DrawEventMetadata> metadataList = new ArrayList<>();
 

--- a/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/common/service/EventServiceTest.java
@@ -1,6 +1,8 @@
 package hyundai.softeer.orange.event.common.service;
 
 import hyundai.softeer.orange.common.ErrorCode;
+import hyundai.softeer.orange.core.JsonUtil;
+import hyundai.softeer.orange.event.common.EventConst;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.EventFieldMapperMatcher;
 import hyundai.softeer.orange.event.common.component.eventFieldMapper.mapper.FcfsEventFieldMapper;
 import hyundai.softeer.orange.event.common.entity.EventFrame;
@@ -17,8 +19,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,6 +48,12 @@ class EventServiceTest {
 
     @Mock
     private EventKeyGenerator keyGenerator;
+
+    @Mock
+    private RedisTemplate<String, Object> eventDtoRedisTemplate;
+
+    @Mock
+    private JsonUtil jsonUtil;
 
     @BeforeEach
     void setUp() {
@@ -85,5 +98,123 @@ class EventServiceTest {
         eventService.createEvent(eventDto);
 
         verify(emRepo, times(1)).save(any(EventMetadata.class));
+    }
+
+    @DisplayName("대응되는 임시 이벤트가 있다면 불러옴")
+    @Test
+    void getTempEvent_GetEventIfExist() {
+        long adminId = 10;
+        String expectedKey = EventConst.ADMIN_TEMP(adminId);
+
+        EventDto eventDto = mock(EventDto.class);
+        ValueOperations<String, Object> ops = mock(ValueOperations.class);
+        when(eventDtoRedisTemplate.opsForValue()).thenReturn(ops);
+        when(ops.get(anyString())).thenReturn(Optional.of(eventDto));
+
+        eventService.getTempEvent(adminId);
+
+        verify(eventDtoRedisTemplate, times(1)).opsForValue();
+        verify(ops, times(1)).get(expectedKey);
+        verify(jsonUtil, times(1)).parseObj(any(), any());
+    }
+
+    @DisplayName("대응되는 임시 이벤트가 없다면 예외")
+    @Test
+    void getTempEvent_throwIfEventNotFound() {
+        long adminId = 10;
+        String expectedKey = EventConst.ADMIN_TEMP(adminId);
+
+        ValueOperations<String, Object> ops = mock(ValueOperations.class);
+        when(eventDtoRedisTemplate.opsForValue()).thenReturn(ops);
+        when(ops.get(expectedKey)).thenReturn(null);
+
+        assertThatThrownBy(() -> {
+            eventService.getTempEvent(adminId);
+        }).isInstanceOf(EventException.class)
+        .hasMessage(ErrorCode.TEMP_EVENT_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이벤트를 임시 저장")
+    @Test
+    void saveTempEvent_successfully() {
+        long adminId = 10;
+        String expectedKey = EventConst.ADMIN_TEMP(adminId);
+        ValueOperations<String, Object> ops = mock(ValueOperations.class);
+        when(eventDtoRedisTemplate.opsForValue()).thenReturn(ops);
+        EventDto eventDto = mock(EventDto.class);
+        eventService.saveTempEvent(adminId, eventDto);
+        verify(eventDtoRedisTemplate, times(1)).opsForValue();
+        verify(ops, times(1)).set(eq(expectedKey), eq(eventDto), anyLong(), eq(TimeUnit.HOURS));
+    }
+
+    @DisplayName("이벤트가 없다면 404")
+    @Test
+    void deleteEvent_throwIfEventNotFound() {
+        String eventId = "test";
+        when(emRepo.findFirstByEventId(anyString())).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> {
+            eventService.deleteEvent(eventId);
+        }).isInstanceOf(EventException.class)
+                .hasMessage(ErrorCode.EVENT_NOT_FOUND.getMessage());
+    }
+
+    @DisplayName("이벤트가 진행 중이면 삭제 불가")
+    @Test
+    void deleteEvent_throwIfEventRunning() {
+        String eventId = "test";
+        Instant now = Instant.now();
+
+        Instant start = now.minus(1, ChronoUnit.HOURS);
+        Instant end = now.plus(1, ChronoUnit.HOURS);
+        EventMetadata eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .startTime(start)
+                .endTime(end)
+                .build();
+        when(emRepo.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+
+        assertThatThrownBy(() -> {
+            eventService.deleteEvent(eventId);
+        }).isInstanceOf(EventException.class)
+        .hasMessage(ErrorCode.CANNOT_DELETE_EVENT_RUNNING.getMessage());
+    }
+
+    @DisplayName("이벤트가 완료되었으면 삭제 불가")
+    @Test
+    void deleteEvent_throwIfEventEnded() {
+        String eventId = "test";
+        Instant now = Instant.now();
+
+        Instant start = now.minus(2, ChronoUnit.HOURS);
+        Instant end = now.minus(1, ChronoUnit.HOURS);
+        EventMetadata eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .startTime(start)
+                .endTime(end)
+                .build();
+        when(emRepo.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+        assertThatThrownBy(() -> {
+            eventService.deleteEvent(eventId);
+        }).isInstanceOf(EventException.class)
+        .hasMessage(ErrorCode.CANNOT_DELETE_EVENT_ENDED.getMessage());
+    }
+
+    @DisplayName("이벤트가 시작되기 전이라면 삭제 가능")
+    @Test
+    void deleteEvent_successfullyBeforeStart() {
+        String eventId = "test";
+        Instant now = Instant.now();
+
+        Instant start = now.plus(1, ChronoUnit.HOURS);
+        Instant end = now.plus(2, ChronoUnit.HOURS);
+        EventMetadata eventMetadata = EventMetadata.builder()
+                .eventId(eventId)
+                .startTime(start)
+                .endTime(end)
+                .build();
+        when(emRepo.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
+
+        eventService.deleteEvent(eventId);
+        verify(emRepo, times(1)).delete(any(EventMetadata.class));
     }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #131

# 📝 작업 내용

이벤트 삭제 기능을 추가했습니다. 정책은 다음과 같습니다.

1. 이벤트가 없으면 404 예외를 반환한다.
2. 이벤트가 있을 때는 이벤트가 시작되기 전에만 삭제할 수 있다.
