### PR TITLE
[refactor] 인증번호 전송 기능 리팩토링 + DrawEvent 복수개 조회하지 않도록 수정 (#133)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventFrameRepository.java
@@ -16,6 +16,8 @@ public interface EventFrameRepository extends JpaRepository<EventFrame, Long> {
 
     Optional<EventFrame> findByFrameId(String frameId);
 
+    boolean existsByFrameId(String frameId);
+
     @Query("SELECT ef.frameId FROM EventFrame ef WHERE ef.frameId LIKE %:search%")
     List<String> findAllFrameIdsWithLike(@Param("search") String search);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventRepository.java
@@ -14,7 +14,11 @@ public interface DrawEventRepository extends JpaRepository<DrawEvent, Long> {
     Optional<DrawEvent> findByEventId(@Param("eventId") String eventId);
 
     // eventframeId로 eventmetadata의 drawevent를 찾는 fetch join 쿼리 (N+1 문제 방지)
-    @Query(value = "SELECT d FROM DrawEvent d JOIN FETCH d.eventMetadata em JOIN FETCH em.eventFrame ef WHERE ef.frameId = :eventFrameId")
+    @Query(value = "SELECT d.* FROM draw_event d " +
+            "JOIN event_metadata em ON d.event_metadata_id = em.id " +
+            "JOIN event_frame ef ON em.event_frame_id = ef.id " +
+            "WHERE ef.frame_id = :eventFrameId " +
+            "LIMIT 1", nativeQuery = true)
     Optional<DrawEvent> findByEventFrameId(@Param("eventFrameId") String eventFrameId);
 
 //    @Modifying // 수정 쿼리는 Modifying 필요

--- a/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
@@ -5,7 +5,6 @@ import hyundai.softeer.orange.common.dto.TokenDto;
 import hyundai.softeer.orange.eventuser.dto.RequestAuthCodeDto;
 import hyundai.softeer.orange.eventuser.dto.RequestUserDto;
 import hyundai.softeer.orange.eventuser.service.EventUserService;
-import hyundai.softeer.orange.eventuser.service.SmsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 public class EventUserController {
 
     private final EventUserService eventUserService;
-    private final SmsService smsService;
 
     // 로그인
     @Tag(name = "EventUser")
@@ -42,14 +40,18 @@ public class EventUserController {
 
     // 인증번호 전송
     @Tag(name = "EventUser")
-    @PostMapping("/send-auth")
+    @PostMapping("/send-auth/{eventFrameId}")
     @Operation(summary = "인증번호 전송", description = "유저의 전화번호에 인증번호를 전송한다.", responses = {
             @ApiResponse(responseCode = "200", description = "인증번호 전송 성공"),
             @ApiResponse(responseCode = "400", description = "입력받은 정보의 유효성 검사가 실패했을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "해당 이벤트 프레임이 존재하지 않을 때",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "해당 이벤트의 유저로 이미 가입되어 있을 때",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<Void> sendAuthCode(@RequestBody @Valid RequestUserDto dto) {
-        smsService.sendSms(dto);
+    public ResponseEntity<Void> sendAuthCode(@RequestBody @Valid RequestUserDto dto, @PathVariable String eventFrameId) {
+        eventUserService.sendAuthCode(dto, eventFrameId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -17,6 +17,8 @@ public interface EventUserRepository extends JpaRepository<EventUser, Long>, Cus
 
     Optional<EventUser> findByUserNameAndPhoneNumber(String userName, String phoneNumber);
 
+    boolean existsByPhoneNumberAndEventFrameFrameId(String phoneNumber, String frameId);
+
     Optional<EventUser> findByUserId(String userId);
 
     @Query("SELECT eu FROM EventUser eu WHERE eu.userId IN :userIds")

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/CoolSmsService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/CoolSmsService.java
@@ -1,17 +1,15 @@
 package hyundai.softeer.orange.eventuser.service;
 
-import hyundai.softeer.orange.common.ErrorCode;
 import hyundai.softeer.orange.common.util.ConstantUtil;
 import hyundai.softeer.orange.eventuser.config.CoolSmsApiConfig;
 import hyundai.softeer.orange.eventuser.dto.RequestUserDto;
-import hyundai.softeer.orange.eventuser.exception.EventUserException;
-import hyundai.softeer.orange.eventuser.repository.EventUserRepository;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
 import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,28 +18,23 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
+@Primary
 @Service
 public class CoolSmsService implements SmsService {
 
     private final DefaultMessageService defaultMessageService;
     private final CoolSmsApiConfig coolSmsApiConfig;
     private final StringRedisTemplate stringRedisTemplate;
-    private final EventUserRepository eventUserRepository;
 
-    public CoolSmsService(CoolSmsApiConfig coolSmsApiConfig, StringRedisTemplate stringRedisTemplate, EventUserRepository eventUserRepository) {
+    public CoolSmsService(CoolSmsApiConfig coolSmsApiConfig, StringRedisTemplate stringRedisTemplate) {
         this.defaultMessageService = NurigoApp.INSTANCE.initialize(coolSmsApiConfig.getApiKey(), coolSmsApiConfig.getApiSecret(), coolSmsApiConfig.getUrl());
         this.coolSmsApiConfig = coolSmsApiConfig;
         this.stringRedisTemplate = stringRedisTemplate;
-        this.eventUserRepository = eventUserRepository;
     }
 
     @Override
     @Transactional(readOnly = true)
     public void sendSms(RequestUserDto dto) {
-        if(eventUserRepository.existsByPhoneNumber(dto.getPhoneNumber())) {
-            throw new EventUserException(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS);
-        }
-
         String authCode = generateAuthCode();
         Message message = new Message();
         message.setFrom(coolSmsApiConfig.getFrom());


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #133

# 📝 작업 내용

> 인증번호 전송 기능을 리팩토링하여, sms 관련 모듈은 오직 전송에만 신경쓰도록 하고, 예외처리 같은 경우는 EventUserService에서 전담하도록 수정했습니다. 
~~~
2024-08-22 14:20:01 [http-nio-8080-exec-1] ERROR o.a.c.c.C.[.[.[.[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.dao.IncorrectResultSizeDataAccessException: Query did not return a unique result: 2 results were returned] with root cause
org.hibernate.NonUniqueResultException: Query did not return a unique result: 2 results were returned
~~~
> 한편, DrawEventRepository의 findByEventFrameId() 메서드가 상황에 따라 단일 객체가 아닌 복수개의 객체를 반환해버리는 duplicate 문제가 생겨 limit 1으로 명시적으로 반환하도록 조치했습니다. 
## 참고 이미지 및 자료

# 💬 리뷰 요구사항
