### PR TITLE
[fix] 선착순 이벤트 가져오기 조건 잘못되어 있던 버그 수정 (#137)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -41,7 +41,7 @@ public class FcfsManageService {
     // 오늘의 선착순 이벤트 정보(당첨자 수, 시작 시각)를 Redis에 배치
     @Transactional(readOnly = true)
     public void registerFcfsEvents() {
-        List<FcfsEvent> events = fcfsEventRepository.findByStartTimeBetween(Instant.now(), Instant.now().plus(100, ChronoUnit.DAYS));
+        List<FcfsEvent> events = fcfsEventRepository.findByStartTimeBetween(Instant.now(), Instant.now().plus(1, ChronoUnit.DAYS));
         events.forEach(this::prepareEventInfo);
         log.info("Today's FCFS events were registered in Redis");
     }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #137

# 📝 작업 내용

~~~java
// 오늘의 선착순 이벤트 정보(당첨자 수, 시작 시각)를 Redis에 배치
@Transactional(readOnly = true)
public void registerFcfsEvents() {
    List<FcfsEvent> events = fcfsEventRepository.findByStartTimeBetween(Instant.now(), Instant.now().plus(1, ChronoUnit.DAYS));
    events.forEach(this::prepareEventInfo);
    log.info("Today's FCFS events were registered in Redis");
}
~~~
> 현재 선착순 이벤트의 정보를 가져오는 로직의 기준 시간이 100일로 되어 있어, 1일로 신속하게 수정했습니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
