### PR TITLE
[fix] 이벤트 식별자가 누락되어 로그인 필터링 과정에서 발생하던 에러 수정 (#140)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/controller/FcfsController.java
@@ -42,15 +42,8 @@ public class FcfsController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     public ResponseEntity<ResponseFcfsResultDto> participate(@Parameter(hidden = true) @EventUserAnnotation EventUserInfo userInfo, @PathVariable String eventId, @RequestBody RequestAnswerDto dto) {
-        // 정답 판정 시간 측정
-        long timeMillis = System.currentTimeMillis();
         boolean answerResult = fcfsAnswerService.judgeAnswer(eventId, dto.getAnswer());
-        log.info("judgeAnswer: {}ms", System.currentTimeMillis() - timeMillis);
-
-        // 이벤트 참여 시간 측정
-        long timeMillis2 = System.currentTimeMillis();
         boolean isWin = answerResult && fcfsService.participate(eventId, userInfo.getUserId());
-        log.info("participate: {}ms", System.currentTimeMillis() - timeMillis2);
         return ResponseEntity.ok(new ResponseFcfsResultDto(answerResult, isWin));
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/RedisLuaFcfsService.java
@@ -58,7 +58,6 @@ public class RedisLuaFcfsService implements FcfsService {
             throw new FcfsEventException(ErrorCode.INVALID_EVENT_TIME);
         }
 
-        long timeMillis = System.currentTimeMillis();
         String script = "local count = redis.call('zcard', KEYS[1]) " +
                 "if count < tonumber(ARGV[1]) then " +
                 "    redis.call('zadd', KEYS[1], ARGV[2], ARGV[3]) " +
@@ -74,7 +73,6 @@ public class RedisLuaFcfsService implements FcfsService {
                 String.valueOf(timestamp),
                 userId
         );
-        log.info("LuaScript 소요시간: {}", System.currentTimeMillis() - timeMillis);
 
         if(result == null || result <= 0) {
             log.info("Event Finished: {},", stringRedisTemplate.opsForZSet().zCard(FcfsUtil.winnerFormatting(key)));
@@ -87,7 +85,6 @@ public class RedisLuaFcfsService implements FcfsService {
         stringRedisTemplate.opsForZSet().add(FcfsUtil.winnerFormatting(key), userId, System.currentTimeMillis());
         stringRedisTemplate.opsForSet().add(FcfsUtil.participantFormatting(key), userId);
         log.info("Participating Success: {}, User ID: {}, Timestamp: {}", eventSequence, userId, timestamp);
-        log.info("성공까지 걸린 시간: {}", System.currentTimeMillis() - startTimeMillis);
         return true;
     }
 

--- a/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/controller/EventUserController.java
@@ -25,7 +25,7 @@ public class EventUserController {
 
     // 로그인
     @Tag(name = "EventUser")
-    @PostMapping("/login")
+    @PostMapping("/login/{eventFrameId}")
     @Operation(summary = "로그인", description = "유저의 정보를 입력받아 로그인한다.", responses = {
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(schema = @Schema(implementation = TokenDto.class))),
@@ -34,8 +34,8 @@ public class EventUserController {
             @ApiResponse(responseCode = "404", description = "해당 정보를 갖는 유저가 존재하지 않을 때",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    public ResponseEntity<TokenDto> login(@RequestBody @Valid RequestUserDto dto) {
-        return ResponseEntity.ok(eventUserService.login(dto));
+    public ResponseEntity<TokenDto> login(@RequestBody @Valid RequestUserDto dto, @PathVariable String eventFrameId) {
+        return ResponseEntity.ok(eventUserService.login(dto, eventFrameId));
     }
 
     // 인증번호 전송

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -4,12 +4,9 @@ import hyundai.softeer.orange.eventuser.dto.EventUserScoreDto;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.FluentQuery;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -17,9 +14,10 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface EventUserRepository extends JpaRepository<EventUser, Long>, CustomEventUserRepository, JpaSpecificationExecutor<EventUser> {
+public interface EventUserRepository extends JpaRepository<EventUser, Long>, CustomEventUserRepository {
 
-    Optional<EventUser> findByUserNameAndPhoneNumber(String userName, String phoneNumber);
+    @EntityGraph(attributePaths = {"eventFrame"})
+    Optional<EventUser> findByUserNameAndPhoneNumberAndEventFrameFrameId(String userName, String phoneNumber, String eventFrameId);
 
     boolean existsByPhoneNumberAndEventFrameFrameId(String phoneNumber, String frameId);
 
@@ -38,4 +36,4 @@ public interface EventUserRepository extends JpaRepository<EventUser, Long>, Cus
             "JOIN event_metadata e ON e.event_frame_id = ef.id " +
             "WHERE e.id = :rawEventId", nativeQuery = true)
     List<EventUserScoreDto> findAllUserScoreByDrawEventId(@Param("rawEventId") long rawEventId);
- }
+}

--- a/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/repository/EventUserRepository.java
@@ -4,7 +4,6 @@ import hyundai.softeer.orange.eventuser.dto.EventUserScoreDto;
 import hyundai.softeer.orange.eventuser.entity.EventUser;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,8 +14,6 @@ import java.util.Optional;
 
 @Repository
 public interface EventUserRepository extends JpaRepository<EventUser, Long>, CustomEventUserRepository {
-
-    @EntityGraph(attributePaths = {"eventFrame"})
     Optional<EventUser> findByUserNameAndPhoneNumberAndEventFrameFrameId(String userName, String phoneNumber, String eventFrameId);
 
     boolean existsByPhoneNumberAndEventFrameFrameId(String phoneNumber, String frameId);

--- a/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
+++ b/src/main/java/hyundai/softeer/orange/eventuser/service/EventUserService.java
@@ -43,8 +43,8 @@ public class EventUserService {
      * 3. 유저 uuid 기반 JWT 토큰 발급
      */
     @Transactional(readOnly = true)
-    public TokenDto login(RequestUserDto dto) {
-        EventUser eventUser = eventUserRepository.findByUserNameAndPhoneNumber(dto.getName(), dto.getPhoneNumber())
+    public TokenDto login(RequestUserDto dto, String eventFrameId) {
+        EventUser eventUser = eventUserRepository.findByUserNameAndPhoneNumberAndEventFrameFrameId(dto.getName(), dto.getPhoneNumber(), eventFrameId)
                 .orElseThrow(() -> new EventUserException(ErrorCode.EVENT_USER_NOT_FOUND));
 
         log.info("EventUser {} found, Login success", eventUser.getUserName());

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserControllerTest.java
@@ -68,10 +68,10 @@ class EventUserControllerTest {
         requestUserDto = new RequestUserDto(name, phoneNumber);
         String requestBody = mapper.writeValueAsString(requestUserDto);
         String responseBody = mapper.writeValueAsString(tokenDto);
-        when(eventUserService.login(any(RequestUserDto.class))).thenReturn(tokenDto);
+        when(eventUserService.login(any(RequestUserDto.class), anyString())).thenReturn(tokenDto);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isOk())
@@ -91,7 +91,7 @@ class EventUserControllerTest {
         String responseBody = mapper.writeValueAsString(expectedErrors);
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -103,10 +103,10 @@ class EventUserControllerTest {
     void login404Test() throws Exception {
         // given
         String requestBody = mapper.writeValueAsString(requestUserDto);
-        when(eventUserService.login(any(RequestUserDto.class))).thenThrow(new EventUserException(ErrorCode.USER_NOT_FOUND));
+        when(eventUserService.login(any(RequestUserDto.class), anyString())).thenThrow(new EventUserException(ErrorCode.USER_NOT_FOUND));
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/event-user/login/" + eventFrameId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isNotFound());

--- a/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/eventuser/EventUserServiceTest.java
@@ -77,11 +77,11 @@ class EventUserServiceTest {
     @Test
     void loginTest() {
         // given
-        given(eventUserRepository.findByUserNameAndPhoneNumber(requestUserDto.getName(), requestUserDto.getPhoneNumber()))
+        given(eventUserRepository.findByUserNameAndPhoneNumberAndEventFrameFrameId(requestUserDto.getName(), requestUserDto.getPhoneNumber(), eventFrameId))
                 .willReturn(Optional.of(eventUser));
 
         // when
-        TokenDto result = eventUserService.login(requestUserDto);
+        TokenDto result = eventUserService.login(requestUserDto, eventFrameId);
 
         // then
         assertThat(result).isNotNull();
@@ -91,11 +91,11 @@ class EventUserServiceTest {
     @Test
     void loginNotFoundTest() {
         // given
-        given(eventUserRepository.findByUserNameAndPhoneNumber(requestUserDto.getName(), requestUserDto.getPhoneNumber()))
+        given(eventUserRepository.findByUserNameAndPhoneNumberAndEventFrameFrameId(requestUserDto.getName(), requestUserDto.getPhoneNumber(), eventFrameId))
                 .willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> eventUserService.login(requestUserDto))
+        assertThatThrownBy(() -> eventUserService.login(requestUserDto, eventFrameId))
                 .isInstanceOf(EventUserException.class)
                 .hasMessage(ErrorCode.EVENT_USER_NOT_FOUND.getMessage());
     }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #140 

- #141
> 충돌로 인해 다시 브랜치를 생성하고 Cherry-Pick 했습니다.

# 📝 작업 내용

> 일단 어제 달아두었던 선착순 이벤트 비즈니스 로직에 오버헤드가 거의 없는 것을 확인하여 관련 로그를 제거했습니다.
> 다음으로, 로그인 처리 과정에서 하나의 유저(이름+전화번호)가 여러 이벤트에 로그인할 수 있는 상황을 제대로 처리하지 못하는 오류가 있어, 이를 신속하게 해결했습니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
