### PR TITLE
[fix] 스케줄러 의도대로 동작하지 않는 버그 수정 (#143)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/scheduler/FcfsScheduler.java
@@ -6,6 +6,8 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -15,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 @Component
 public class FcfsScheduler {
 
+    private static final Logger log = LoggerFactory.getLogger(FcfsScheduler.class);
     // 분산 환경에서 메서드가 여러 번 실행되는 것을 방지하기 위해 분산 락 도입
     private final RedissonClient redissonClient;
     private final FcfsManageService fcfsManageService;
@@ -22,6 +25,7 @@ public class FcfsScheduler {
     // 매일 자정 1분마다 실행되며, 오늘의 선착순 이벤트에 대한 정보를 DB에서 Redis로 이동시킨다.
     @Scheduled(cron = "0 1 0 * * *")
     public void registerFcfsEvents() {
+        log.info("Move the information of FCFS Events from DB to Redis");
         RLock lock = redissonClient.getLock(ConstantUtil.DB_TO_REDIS_LOCK);
         try {
             // 5분동안 락 점유
@@ -40,6 +44,7 @@ public class FcfsScheduler {
     // 매일 자정마다 실행되며, 선착순 이벤트 당첨자들을 Redis에서 DB로 이동시킨다.
     @Scheduled(cron = "0 0 0 * * *")
     public void registerWinners() {
+        log.info("Move the result of FCFS Events from Redis to DB");
         RLock lock = redissonClient.getLock(ConstantUtil.REDIS_TO_DB_LOCK);
         try {
             // 5분동안 락 점유

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -62,7 +62,7 @@ public class FcfsManageService {
             Set<String> userIds = stringRedisTemplate.opsForZSet().range(FcfsUtil.winnerFormatting(fcfsEventId), 0, -1);
             if(userIds == null || userIds.isEmpty()) {
                 log.info("No winners in FCFS Event {}", fcfsEventId);
-                return;
+                continue;
             }
 
             FcfsEvent event = fcfsEventRepository.findById(Long.parseLong(fcfsEventId))

--- a/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
+++ b/src/main/java/hyundai/softeer/orange/event/fcfs/service/FcfsManageService.java
@@ -49,38 +49,44 @@ public class FcfsManageService {
     // redis에 저장된 모든 선착순 이벤트의 당첨자 정보를 DB로 이관
     @Transactional
     public void registerWinners() {
-        Set<String> fcfsIds = stringRedisTemplate.keys("*:count");
-        if (fcfsIds == null || fcfsIds.isEmpty()) {
+        Set<String> fcfsKeys = stringRedisTemplate.keys("*:count");
+        if (fcfsKeys == null || fcfsKeys.isEmpty()) {
+            log.info("There are no FCFS events in yesterday");
             return;
         }
 
-        for(String fcfsId : fcfsIds) {
-            String eventId = fcfsId.replace(":count", "").replace("fcfs:", "");
-            Set<String> userIds = stringRedisTemplate.opsForZSet().range(FcfsUtil.winnerFormatting(eventId), 0, -1);
+        // 당첨자 관련 정보 조합하여 Entity 생성
+        log.info("keys for FCFS Events: {}", fcfsKeys);
+        for(String key : fcfsKeys) {
+            String fcfsEventId = key.replace(":count", "").replace("fcfs:", "");
+            Set<String> userIds = stringRedisTemplate.opsForZSet().range(FcfsUtil.winnerFormatting(fcfsEventId), 0, -1);
             if(userIds == null || userIds.isEmpty()) {
+                log.info("No winners in FCFS Event {}", fcfsEventId);
                 return;
             }
 
-            FcfsEvent event = fcfsEventRepository.findById(Long.parseLong(eventId))
+            FcfsEvent event = fcfsEventRepository.findById(Long.parseLong(fcfsEventId))
                     .orElseThrow(() -> new FcfsEventException(ErrorCode.FCFS_EVENT_NOT_FOUND));
 
             List<EventUser> users = eventUserRepository.findAllByUserId(userIds.stream().toList());
             List<FcfsEventWinningInfo> winningInfos = users
                     .stream()
-                    .map(user -> FcfsEventWinningInfo.of(event, user, getTimeFromScore(stringRedisTemplate.opsForZSet().score(FcfsUtil.winnerFormatting(eventId), user.getUserId()))))
+                    .map(user -> FcfsEventWinningInfo.of(event, user, getTimeFromScore(stringRedisTemplate.opsForZSet().score(FcfsUtil.winnerFormatting(fcfsEventId), user.getUserId()))))
                     .toList();
 
+            log.info("Winners of FCFS event {} were registered in DB", fcfsEventId);
             fcfsEventWinningInfoRepository.saveAll(winningInfos);
-            deleteEventInfo(eventId);
+            deleteEventInfo(fcfsEventId);
         }
 
+        // PK를 간접적으로 보관하던 eventId 제거
         Set<String> eventIds = stringRedisTemplate.keys("*:eventId");
         if(eventIds != null && !eventIds.isEmpty()) {
             for(String eventId : eventIds) {
                 stringRedisTemplate.delete(eventId);
             }
         }
-        log.info("Winners of all FCFS events were registered in DB");
+        log.info("Registering winners of FCFS events in DB is completed");
     }
 
     // 특정 선착순 이벤트의 정보 조회


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #143

# 📝 작업 내용
> 자정에 발동하는 스케줄러가 호출하는 메서드 registerWinners()에 버그가 있어 수정하였습니다.
> 구체적으로, 선착순 이벤트의 결과에 대한 정보를 순회하던 중 당첨자가 존재하지 않는 선착순 이벤트를 감지하는 경우 return; 문으로 인해 이후 모든 선착순 이벤트 결과 이관 기능이 동작하지 않는 버그가 있었습니다.
> return문을 continue로 대체하여 문제를 해결하였고, 로컬에서 테스트 결과 정상적으로 Redis to DB 동작이 실행되는 것을 검증하였습니다. 

# 관련 이미지 및 자료
~~~
2024-08-22 23:53:24 [http-nio-8080-exec-6] INFO  h.s.o.comment.service.CommentService - fetching comments of the-ㅏona
Hibernate: select ef1_0.id,ef1_0.frame_id,ef1_0.name from event_frame ef1_0 where ef1_0.frame_id=?
Hibernate: select fe1_0.id,fe1_0.end_time,fe1_0.event_metadata_id,fe1_0.participant_count,fe1_0.prize_info,fe1_0.start_time from fcfs_event fe1_0 where fe1_0.start_time between ? and ?
Hibernate: select em1_0.id,em1_0.description,em1_0.end_time,em1_0.event_frame_id,em1_0.event_id,em1_0.event_type,em1_0.name,em1_0.start_time,em1_0.status,em1_0.url from event_metadata em1_0 where em1_0.id=?
2024-08-23 00:01:00 [scheduling-1] INFO  h.s.o.e.f.service.FcfsManageService - Registered FCFS event: 4
Hibernate: select em1_0.id,em1_0.description,em1_0.end_time,em1_0.event_frame_id,em1_0.event_id,em1_0.event_type,em1_0.name,em1_0.start_time,em1_0.status,em1_0.url from event_metadata em1_0 where em1_0.id=?
2024-08-23 00:01:00 [scheduling-1] INFO  h.s.o.e.f.service.FcfsManageService - Registered FCFS event: 25
2024-08-23 00:01:00 [scheduling-1] INFO  h.s.o.e.f.service.FcfsManageService - Today's FCFS events were registered in Redis
~~~
보시다시피 실제 prod 환경에서 자정 정각에 Redis to DB 메서드가 동작하지 않고, 이후 1분이 될 때 DB to Redis만 동작하고 있던 것을 확인하실 수 있습니다. 