### PR TITLE
[fix] 추첨 이벤트 결과 당첨자 1명만 조회되던 버그 수정 (#145)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventWinningInfoRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/repository/DrawEventWinningInfoRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 public interface DrawEventWinningInfoRepository extends JpaRepository<DrawEventWinningInfo, Long>, CustomDrawEventWinningInfoRepository {
     @EntityGraph(attributePaths = {"eventUser"})
-    List<DrawEventWinningInfo> findAllById(Long id);
+    List<DrawEventWinningInfo> findAllByDrawEventId(Long eventId);
 }

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventService.java
@@ -78,7 +78,7 @@ public class DrawEventService {
         if(drawEvent == null) throw new DrawEventException(ErrorCode.EVENT_NOT_FOUND);
 
         // 당첨자 목록 반환
-        return deWinningInfoRepository.findAllById(drawEvent.getId())
+        return deWinningInfoRepository.findAllByDrawEventId(drawEvent.getId())
                 .stream()
                 .map(ResponseDrawWinnerDto::new)
                 .toList();

--- a/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
+++ b/src/test/java/hyundai/softeer/orange/event/draw/service/DrawEventServiceTest.java
@@ -199,7 +199,7 @@ class DrawEventServiceTest {
         var eventMetadata = createEventMetadata(eventId, EventType.draw, Instant.now());
         eventMetadata.updateDrawEvent(drawEvent);
         when(emRepository.findFirstByEventId(eventId)).thenReturn(Optional.of(eventMetadata));
-        when(deWinningInfoRepository.findAllById(drawEvent.getId())).thenReturn(List.of(DrawEventWinningInfo.of(1L, drawEvent, eventUser)));
+        when(deWinningInfoRepository.findAllByDrawEventId(drawEvent.getId())).thenReturn(List.of(DrawEventWinningInfo.of(1L, drawEvent, eventUser)));
 
         // when
         var result = deService.getDrawEventWinner(eventId);
@@ -207,7 +207,7 @@ class DrawEventServiceTest {
         // then
         assertThat(result).isNotEmpty();
         verify(emRepository, times(1)).findFirstByEventId(eventId);
-        verify(deWinningInfoRepository, times(1)).findAllById(drawEvent.getId());
+        verify(deWinningInfoRepository, times(1)).findAllByDrawEventId(drawEvent.getId());
     }
 
     @DisplayName("getDrawEventStatus: 대응되는 이벤트가 존재하지 않으면 예외 반환")


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #145

# 📝 작업 내용

> 기존 추첨 결과 조회에서 사용되는 findAllById() 메서드는 설계 의도였던 draw event id로 조회하는 것이 아니라 실제 id(PK)로 조회하는 문제가 있어 추첨 결과가 오직 1명으로만 나타나는 문제가 있었습니다.
> 
> 초기 의도대로 draw event id를 기반으로 조회하도록 재설정한 결과 로컬에서 문제 없이 복수개의 엔티티를 조회하는 것을 확인할 수 있었습니다.
 
## 참고 이미지 및 자료

# 💬 리뷰 요구사항