### PR TITLE
[fix] 이벤트 유저 검색에 페이징 동작하지 않는 현상 수정(#147) 

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -109,6 +109,8 @@ public class AdminEventController {
         return ResponseEntity.ok().build();
     }
 
+    public ResponseEntity<Void>
+
     /**
      * @param eventDto 수정된 이벤트 정보
      */

--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -94,7 +94,6 @@ public class AdminEventController {
     /**
      *
      * @param eventId 이벤트 ID. HD000000~로 시작하는 그것
-     * @return 해당 이벤트에 대한 정보
      */
     @DeleteMapping("{eventId}")
     @Operation(summary = "이벤트 제거", description = "이벤트를 제거한다. 시작 전의 이벤트만 삭제할 수 있다.", responses = {
@@ -109,7 +108,16 @@ public class AdminEventController {
         return ResponseEntity.ok().build();
     }
 
-    public ResponseEntity<Void>
+    @DeleteMapping
+    @Operation(summary = "이벤트 목록 제거", description = "이벤트 목록을 제거한다. 시작 전의 이벤트만 삭제할 수 있다.", responses = {
+            @ApiResponse(responseCode = "200", description = "이벤트를 정상적으로 삭제",content = @Content(schema = @Schema(implementation = Void.class))),
+            @ApiResponse(responseCode = "400", description = "삭제하지 못한 이벤트 존재", content = @Content(schema = @Schema(implementation = DeleteEventNotAllowedReasonDto[].class)))
+    })
+    public ResponseEntity<List<DeleteEventNotAllowedReasonDto>> deleteEvents(@Valid @RequestBody DeleteEventsDto dto) {
+        var result = eventService.deleteEvents(dto.getEventIds());
+        if(result == null) return ResponseEntity.ok().build();
+        return ResponseEntity.badRequest().body(result);
+    }
 
     /**
      * @param eventDto 수정된 이벤트 정보

--- a/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/repository/EventMetadataRepository.java
@@ -7,11 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface EventMetadataRepository extends JpaRepository<EventMetadata, Long>, JpaSpecificationExecutor<EventMetadata> {
     Optional<EventMetadata> findFirstByEventId(String eventId);
+
+    List<EventMetadata> findByEventIdIn(List<String> eventIds);
 
     @Query("SELECT e from EventMetadata e join fetch e.eventFrame WHERE e.eventId = :eventId")
     Optional<EventMetadata> findByEventIdWithEventFrame(@Param("eventId") String eventId);

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
@@ -33,6 +33,12 @@ public class DrawEventDrawMachine {
     @Async
     @Transactional
     public CompletableFuture<Void> draw(DrawEvent drawEvent) {
+        try{
+            Thread.sleep(1000 * 60 * 1);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         long drawEventRawId = drawEvent.getId();
         // 점수 계산. 추후 추첨 과정과 분리될 수도 있음.
         List<DrawEventScorePolicy> policies = drawEvent.getPolicyList();

--- a/src/main/java/hyundai/softeer/orange/event/dto/DeleteEventNotAllowedReasonDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/DeleteEventNotAllowedReasonDto.java
@@ -1,0 +1,3 @@
+package hyundai.softeer.orange.event.dto;
+
+public record DeleteEventNotAllowedReasonDto(String id, String reason) {}

--- a/src/main/java/hyundai/softeer/orange/event/dto/DeleteEventsDto.java
+++ b/src/main/java/hyundai/softeer/orange/event/dto/DeleteEventsDto.java
@@ -1,0 +1,12 @@
+package hyundai.softeer.orange.event.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class DeleteEventsDto {
+    @NotEmpty
+    List<String> eventIds;
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #147

# 📝 작업 내용

1. 유저 탐색에 페이징이 동작하도록 수정했습니다.
2. 이벤트 다중 삭제 기능을 추가했습니다.
3. 추첨 이벤트를 테스트하기 위해 추첨 이벤트에 1분의 대기시간을 주었습니다. (현재 추첨이 너무 빠르게 종료되어 정상적으로 동작하는지 확인하기 어렵습니다.)
