### PR TITLE
[fix] deleteAllInBatch로 인해 이벤트의 연관관계를 삭제하지 못해 외래키 에러가 발생하던 문제 수정 (#147)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode {
     ALREADY_PARTICIPATED(HttpStatus.CONFLICT, "이미 참여한 사용자입니다."),
     PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 전화번호입니다."),
     ALREADY_DRAWN(HttpStatus.CONFLICT, "이미 추첨된 이벤트입니다."),
+    EDIT_TO_DIFFERENT_EVENT_TYPE_NOT_ALLOWED(HttpStatus.CONFLICT,"생성된 이벤트를 다른 타입으로 수정할 수 없습니다"),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생하였습니다.");

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -128,6 +128,7 @@ public class EventService {
         Optional<EventMetadata> metadataOpt = emRepository.findFirstByEventId(eventId);
         EventMetadata eventMetadata = metadataOpt
                 .orElseThrow(() -> new EventException(ErrorCode.EVENT_NOT_FOUND));
+        if(eventDto.getEventType() != eventMetadata.getEventType()) throw new EventException(ErrorCode.EDIT_TO_DIFFERENT_EVENT_TYPE_NOT_ALLOWED);
         eventMetadata.updateName(eventDto.getName());
         eventMetadata.updateDescription(eventDto.getDescription());
         eventMetadata.updateStartTime(eventDto.getStartTime());

--- a/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
+++ b/src/main/java/hyundai/softeer/orange/event/common/service/EventService.java
@@ -265,7 +265,9 @@ public class EventService {
             deleteList.add(metadata);
         }
 
-        emRepository.deleteAllInBatch(deleteList);
+        // deleteAllInBatch는 연관관계를 고려하지 않고 raw Delete 문을 날림. 현재 연관된 DrawEvent / FcfsEvent를 함께 제거해줘야 하므로
+        // 성능이 모자르더라도 연관 관계를 함께 삭제해주는 deleteAll을 이용
+        emRepository.deleteAll(deleteList);
         return errorResponse;
     }
 

--- a/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
+++ b/src/main/java/hyundai/softeer/orange/event/draw/service/DrawEventDrawMachine.java
@@ -34,7 +34,7 @@ public class DrawEventDrawMachine {
     @Transactional
     public CompletableFuture<Void> draw(DrawEvent drawEvent) {
         try{
-            Thread.sleep(1000 * 60 * 1);
+            Thread.sleep(1000 * 5 * 1);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #147

# 📝 작업 내용

> deleteAllInBatch는 raw sql DELETE 명령을 날리며, CascadeType에 의한 자동 제거를 수행하지 않습니다. 연관된 fcfs event / draw event를 모두 찾아 삭제한 후 이벤트를 삭제하게 할 수도 있겠으나, 이 경우 JPA에 의한 cascade을 사용하는 의미가 없으므로 deleteAll을 이용합니다. 성능 측면 문제가 심각할 경우 각각 엔티티 타입마다 delete batch를 수행하도록 로직을 변경할 예정입니다.