### PR TITLE
[fix] 기대평 필터링 기준 재조정 (#150)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
+++ b/src/main/java/hyundai/softeer/orange/common/ErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // 400 Bad Request
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "부정적인 표현을 사용하였습니다."),
+    INVALID_COMMENT(HttpStatus.BAD_REQUEST, "긍정적인 기대평을 작성해주세요."),
     INVALID_JSON(HttpStatus.BAD_REQUEST, "잘못된 JSON 형식입니다."),
     INVALID_URL(HttpStatus.BAD_REQUEST, "유효하지 않은 URL입니다."),
     INVALID_INPUT_EVENT_TIME(HttpStatus.BAD_REQUEST, "입력된 시간 중 일부가 조건에 맞지 않습니다."),

--- a/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
+++ b/src/main/java/hyundai/softeer/orange/common/util/ConstantUtil.java
@@ -25,7 +25,7 @@ public class ConstantUtil {
     public static final String DB_TO_REDIS_LOCK = "FCFS_MANAGE_DB_TO_REDIS";
     public static final String REDIS_TO_DB_LOCK = "FCFS_MANAGE_REDIS_TO_DB";
 
-    public static final double LIMIT_NEGATIVE_CONFIDENCE = 99.5;
+    public static final double LIMIT_NEGATIVE_CONFIDENCE = 80;
     public static final int COMMENTS_SIZE = 20;
     public static final int SCHEDULED_TIME = 1000 * 60 * 60 * 2;
     public static final int SHORT_URL_LENGTH = 10;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #150 

# 📝 작업 내용

> 데모데이에서 부정적이나 욕설 등이 포함된 부적절한 기대평에 대한 필터링 기준이 생각보다 너무 널널해서, 필터링 기준을 부정 99.5% 에서 부정 80%까지 낮추어 서비스 내부 부정적 상황을 방지하고자 합니다.
> 부정 기준 조정을 통해 간헐적으로 발생하던 비속어 등이 포함된 댓글에 대한 필터링을 강화할 수 있을 것입니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
