### PR TITLE
[chore] delete many 시 조건을 null 체크로 처리해 항상 예외로 간주하는 문제 수정 (#147)

### DIFF
--- a/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
+++ b/src/main/java/hyundai/softeer/orange/admin/controller/AdminEventController.java
@@ -115,7 +115,7 @@ public class AdminEventController {
     })
     public ResponseEntity<List<DeleteEventNotAllowedReasonDto>> deleteEvents(@Valid @RequestBody DeleteEventsDto dto) {
         var result = eventService.deleteEvents(dto.getEventIds());
-        if(result == null) return ResponseEntity.ok().build();
+        if(result.isEmpty()) return ResponseEntity.ok().build();
         return ResponseEntity.badRequest().body(result);
     }
 


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #147

# 📝 작업 내용

> 삭제 불가능 문제는 해결했지만, 배열에 대해 == null 체크를 수행해 항상 에러로 간주하던 문제가 있었습니다. 해당 문제를 수정합니다.

프로젝트 막바지라 실수가 많네요...